### PR TITLE
fix: apply dynamic time format to seekbar tooltip (#62)

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1917,7 +1917,12 @@ local function osc_init()
         local duration = mp.get_property_number("duration")
         if duration ~= nil and pos ~= nil then
             local possec = duration * (pos / 100)
-            return mp.format_time(possec)
+            local time = mp.format_time(possec)
+            -- If video is less than 1 hour, strip the "00:" prefix
+            if possec < 3600 then
+                time = time:gsub("^00:", "")
+            end
+            return time
         else
             return ""
         end


### PR DESCRIPTION
This PR addresses the inconsistency where the seekbar tooltip wasn't following the same time format as the rest of the OSC.

### Changes

- MM:SS only when seeking positions under 1 hour (e.g., 05:30)
- HH:MM:SS when seeking past 1-hour positions (e.g., 01:23:45)

This matches how the main time display works and follows the behavior of popular video players like YouTube.

Closes #62 