### PR TITLE
Fix skip and jump buttons activating twice

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -812,7 +812,6 @@ local function render_elements(master_ass)
 
                     element.eventresponder[state.active_event_source.."_down"](element)
                 end
-                state.mouse_down_counter = state.mouse_down_counter + 1
             end
         end
         


### PR DESCRIPTION
Fixes https://github.com/Samillion/ModernZ/issues/85

When I remove the line of code, the bug is fixed.

Disclaimer: I don't know what it precisely does or if it breaks anything.