### PR TITLE
fix: sync seekbar time format with time_format option

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -2062,8 +2062,8 @@ local function osc_init()
         if duration ~= nil and pos ~= nil then
             local possec = duration * (pos / 100)
             local time = mp.format_time(possec)
-            -- If video is less than 1 hour, strip the "00:" prefix
-            if possec < 3600 then
+            -- If video is less than 1 hour, and the time format is not fixed, strip the "00:" prefix
+            if possec < 3600 and user_opts.time_format ~= "fixed" then
                 time = time:gsub("^00:", "")
             end
             return time


### PR DESCRIPTION
As requested in #104, this makes it so the time shown by the seekbar is affected by the `time_format` property.

Preview:
![image](https://github.com/user-attachments/assets/9c84f89a-d02a-4617-86c1-99cd4359e41f)
