### PR TITLE
fix: osc scaling behavior

### DIFF
--- a/modernz.conf
+++ b/modernz.conf
@@ -74,7 +74,7 @@ ytdlp_format=
 
 ## Scaling
 # whether to scale the controller with the video
-vidscale=yes
+vidscale=auto
 # scaling of the controller when windowed
 scalewindowed=1.0
 # scaling of the controller when fullscreen

--- a/modernz.lua
+++ b/modernz.lua
@@ -63,7 +63,6 @@ local user_opts = {
     vidscale = "auto",                     -- whether to scale the controller with the video
     scalewindowed = 1.0,                   -- scaling of the controller when windowed
     scalefullscreen = 1.0,                 -- scaling of the controller when fullscreen
-    scaleforcedwindow = 1.0,               -- scaling when rendered on a forced window
 
     -- Time & Volume
     unicodeminus = false,                  -- whether to use the Unicode minus sign character in remaining time

--- a/modernz.lua
+++ b/modernz.lua
@@ -60,7 +60,7 @@ local user_opts = {
                                            -- example "-f bv[vcodec^=avc][ext=mp4]+ba[ext=m4a]/b[ext=mp4]"
 
     -- Scaling
-    vidscale = true,                       -- whether to scale the controller with the video
+    vidscale = "auto",                     -- whether to scale the controller with the video
     scalewindowed = 1.0,                   -- scaling of the controller when windowed
     scalefullscreen = 1.0,                 -- scaling of the controller when fullscreen
     scaleforcedwindow = 1.0,               -- scaling when rendered on a forced window
@@ -1698,18 +1698,23 @@ local function osc_init()
 
     -- set canvas resolution according to display aspect and scaling setting
     local baseResY = 720
-    local display_w, display_h, display_aspect = mp.get_osd_size()
-    local scale = 1
+    local _, display_h, display_aspect = mp.get_osd_size()
+    local scale
 
-    if mp.get_property("video") == "no" then -- dummy/forced window
-        scale = user_opts.scaleforcedwindow
-    elseif state.fullscreen then
+    if state.fullscreen then
         scale = user_opts.scalefullscreen
     else
         scale = user_opts.scalewindowed
     end
 
-    if user_opts.vidscale then
+    local scale_with_video
+    if user_opts.vidscale == "auto" then
+        scale_with_video = mp.get_property_native("osd-scale-by-window")
+    else
+        scale_with_video = user_opts.vidscale == "yes"
+    end
+
+    if scale_with_video then
         osc_param.unscaled_y = baseResY
     else
         osc_param.unscaled_y = display_h


### PR DESCRIPTION
This PR updates the OSC scale calculation code to match upstreams, ensuring that the `osd-scale-by-window` property is respected. This also requires changing `vidscale`'s default from `true` to `auto`. However, since `osd-scale-by-window` defaults to `true`, there are no changes to users with the default config.

**Changes**
---
`vidscale` now defaults to `"auto"`, which respects the `osd-scale-by-window` property (which by default is `true`)

**Preview**
---
| auto                                                                                               | yes                                                                                               | no                                                                                               |
|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| ![Preview - auto](https://github.com/user-attachments/assets/33742552-f381-4c37-9342-bbaddb1677fe) | ![Preview - yes](https://github.com/user-attachments/assets/92a2d697-5d9b-4e35-bd5b-72c201d62fa7) | ![Preview - no](https://github.com/user-attachments/assets/8541caf5-6d26-478a-8e4e-38c3649d27fa) |