### PR TITLE
refactor: download button to use current or default ytdl-format

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -59,7 +59,6 @@ Create `modernz.conf` in your mpv script-opts directory:
 | jump_softrepeat       | yes           | holding jump seek buttons repeats toggle                                                                                                                      |
 | downloadbutton        | yes           | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
 | download_path         | ~~desktop/mpv | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
-| ytdlp_format          |               | optional parameters for yt-dlp <br>example `-f bv[vcodec^=avc][ext=mp4]+ba[ext=m4a]/b[ext=mp4]`                                                               |
 
 ### Scaling
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -70,9 +70,6 @@ jump_softrepeat=yes
 downloadbutton=yes
 # the download path for videos https://mpv.io/manual/master/#paths
 download_path=~~desktop/mpv
-# optional parameters for yt-dlp
-# example "-f bv[vcodec^=avc][ext=mp4]+ba[ext=m4a]/b[ext=mp4]"
-ytdlp_format=
 
 ## Scaling
 # whether to scale the controller with the video

--- a/modernz.lua
+++ b/modernz.lua
@@ -58,8 +58,6 @@ local user_opts = {
 
     downloadbutton = true,                 -- show download button on web videos (requires yt-dlp and ffmpeg)
     download_path = "~~desktop/mpv",       -- the download path for videos https://mpv.io/manual/master/#paths
-    ytdlp_format = "",                     -- optional format parameters for yt-dlp 
-                                           -- example "-f bv[vcodec^=avc][ext=mp4]+ba[ext=m4a]/b[ext=mp4]"
 
     -- Scaling
     vidscale = "auto",                     -- whether to scale the controller with the video
@@ -1003,7 +1001,7 @@ local function render_elements(master_ass)
 
         elseif element.type == "button" then
             if user_opts.hovereffect == "size" then
-                -- add suze hover effect
+                -- add size hover effect
                 local button_lo = element.layout.button
                 local is_clickable = element.eventresponder and (
                     element.eventresponder["mbtn_left_down"] ~= nil or
@@ -1246,6 +1244,10 @@ local function check_path_url()
         path = string.gsub(path, "ytdl://", "https://") -- Replace "ytdl://" with "https://"
     end
 
+    -- use current or default ytdl-format
+    local mpv_ytdl = mp.get_property("file-local-options/ytdl-format") or mp.get_property("ytdl-format") or ""
+    local ytdl_format = (mpv_ytdl and mpv_ytdl ~= "") and "-f " .. mpv_ytdl or "-f " .. "bestvideo+bestaudio/best"
+
     if is_url(path) then
         state.isWebVideo = true
         state.web_video_path = path
@@ -1255,7 +1257,7 @@ local function check_path_url()
             msg.info("Fetching file size...")
             local command = { 
                 "yt-dlp",
-                user_opts.ytdlp_format,
+                ytdl_format,
                 "--no-download",
                 "-O",
                 "%(filesize,filesize_approx)s", -- Fetch file size or approximate size
@@ -2064,9 +2066,12 @@ local function osc_init()
             else
                 mp.command("show-text Downloading...")
                 state.downloading = true
+                -- use current or default ytdl-format
+                local mpv_ytdl = mp.get_property("file-local-options/ytdl-format") or mp.get_property("ytdl-format") or ""
+                local ytdl_format = (mpv_ytdl and mpv_ytdl ~= "") and "-f " .. mpv_ytdl or "-f " .. "bestvideo+bestaudio/best"
                 local command = {
                     "yt-dlp",
-                    user_opts.ytdlp_format,
+                    ytdl_format,
                     "--remux", "mp4",
                     "--add-metadata",
                     "--embed-subs",


### PR DESCRIPTION
That way, the user doesn't have to edit/adjust `ytdl-format` in yet another config file.

The download button will simply grab the same video format (quality), as the current `ytdl-format` or the default one set by mpv which is `bestvideo+bestaudio/best` [[reference](https://mpv.io/manual/master/#options-ytdl-format)]

This is useful for users that utilize scripts such as [ytdlAuto-Format](https://github.com/Samillion/mpv-ytdlautoformat) or [quality-menu](https://github.com/christoph-heinrich/mpv-quality-menu), which will allow them to download the video right away with the current viewing `ytdl-format` set by such format controller scripts.