### PR TITLE
feat: support for multiple hovereffects, color hovereffect & customizable glow amount

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -43,8 +43,9 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 | Option                | Value         | Description                                                                                                                                                   |
 | --------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hovereffect           | glow          | what type of hover effect buttons have: `glow`, `size`. Hover effect is disabled if left empty.                                                               |
+| hovereffect           | size          | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
 | hover_button_size     | 115           | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
+| button_glow_amount    | 5             | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
 | showplaylist          | no            | show `playlist` button                                                                                                                                        |
 | showjump              | yes           | show `jump forward/backward 10 seconds` buttons                                                                                                               |
 | showskip              | no            | show the `skip back/forward (chapter)` buttons                                                                                                                |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -41,25 +41,25 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Buttons
 
-| Option                | Value         | Description                                                                                                                                                   |
-| --------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hovereffect           | size          | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
-| hover_button_size     | 115           | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
-| button_glow_amount    | 5             | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
-| showplaylist          | no            | show `playlist` button                                                                                                                                        |
-| showjump              | yes           | show `jump forward/backward 10 seconds` buttons                                                                                                               |
-| showskip              | no            | show the `skip back/forward (chapter)` buttons                                                                                                                |
-| shownextprev          | yes           | show the `next/previous playlist track` buttons                                                                                                               |
-| showinfo              | no            | show the `info (stats)` button                                                                                                                                |
-| showloop              | yes           | show the `loop` button                                                                                                                                        |
-| showfullscreen_button | yes           | show the `fullscreen toggle` button                                                                                                                           |
-| showontop             | yes           | show `window on top (pin)` button                                                                                                                             |
-| showscreenshot        | no            | show `screenshot` button                                                                                                                                      |
-| screenshot_flag       | subtitles     | flag for the screenshot button. `subtitles` `video` `window` `each-frame` [[details](https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)] |
-| chapter_softrepeat    | yes           | holding chapter skip buttons repeats toggle                                                                                                                   |
-| jump_softrepeat       | yes           | holding jump seek buttons repeats toggle                                                                                                                      |
-| downloadbutton        | yes           | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
-| download_path         | ~~desktop/mpv | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
+| Option                | Value           | Description                                                                                                                                                   |
+| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hovereffect           | size,glow,color | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
+| hover_button_size     | 115             | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
+| button_glow_amount    | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
+| showplaylist          | no              | show `playlist` button                                                                                                                                        |
+| showjump              | yes             | show `jump forward/backward 10 seconds` buttons                                                                                                               |
+| showskip              | no              | show the `skip back/forward (chapter)` buttons                                                                                                                |
+| shownextprev          | yes             | show the `next/previous playlist track` buttons                                                                                                               |
+| showinfo              | no              | show the `info (stats)` button                                                                                                                                |
+| showloop              | yes             | show the `loop` button                                                                                                                                        |
+| showfullscreen_button | yes             | show the `fullscreen toggle` button                                                                                                                           |
+| showontop             | yes             | show `window on top (pin)` button                                                                                                                             |
+| showscreenshot        | no              | show `screenshot` button                                                                                                                                      |
+| screenshot_flag       | subtitles       | flag for the screenshot button. `subtitles` `video` `window` `each-frame` [[details](https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)] |
+| chapter_softrepeat    | yes             | holding chapter skip buttons repeats toggle                                                                                                                   |
+| jump_softrepeat       | yes             | holding jump seek buttons repeats toggle                                                                                                                      |
+| downloadbutton        | yes             | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
+| download_path         | ~~desktop/mpv   | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
 
 ### Scaling
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -35,9 +35,11 @@ middle_buttons_color=#FFFFFF
 playpause_color=#FFFFFF
 # color of an element while held down
 held_element_color=#999999
+# color of a hovered button when hovereffect is: color
+hovereffect_color=#CCCCCC
 
 ## Buttons
-# button hover effect: none, glow, size
+# button hover effect: none, glow, size, color
 hovereffect=glow
 # the relative size (%) of a hovered button if the size effect is selected
 hover_button_size=115

--- a/modernz.conf
+++ b/modernz.conf
@@ -40,7 +40,8 @@ hovereffect_color=#CCCCCC
 
 ## Buttons
 # list of active button hover effects seperated by comma: glow, size, color
-hovereffect=glow, size
+# ex. hovereffect=glow, size, color
+hovereffect=size
 # the relative size (%) of a hovered button if the size effect is selected
 hover_button_size=115
 # the amount of glow a hovered button receives if the glow effect is active

--- a/modernz.conf
+++ b/modernz.conf
@@ -41,7 +41,7 @@ hovereffect_color=#CCCCCC
 ## Buttons
 # list of active button hover effects seperated by comma: glow, size, color
 # ex. hovereffect=glow, size, color
-hovereffect=size
+hovereffect=size,glow,color
 # the relative size (%) of a hovered button if the size effect is selected
 hover_button_size=115
 # the amount of glow a hovered button receives if the glow effect is active

--- a/modernz.conf
+++ b/modernz.conf
@@ -39,8 +39,8 @@ held_element_color=#999999
 hovereffect_color=#CCCCCC
 
 ## Buttons
-# button hover effect: none, glow, size, color
-hovereffect=glow
+# list of active button hover effects seperated by comma: glow, size, color
+hovereffect=glow, size
 # the relative size (%) of a hovered button if the size effect is selected
 hover_button_size=115
 # show playlist button

--- a/modernz.conf
+++ b/modernz.conf
@@ -43,6 +43,8 @@ hovereffect_color=#CCCCCC
 hovereffect=glow, size
 # the relative size (%) of a hovered button if the size effect is selected
 hover_button_size=115
+# the amount of glow a hovered button receives if the glow effect is active
+button_glow_amount=5
 # show playlist button
 showplaylist=no
 # show "jump forward/backward 10 seconds" buttons 

--- a/modernz.lua
+++ b/modernz.lua
@@ -36,9 +36,10 @@ local user_opts = {
     playpause_color = "#FFFFFF",           -- color of play/pause button
     held_element_color = "#999999",        -- color of an element while held down
     thumbnailborder_color = "#111111",     -- color of border for thumbnail (with thumbfast)
+    hovereffect_color = "#CCCCCC",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
-    hovereffect = "size",                  -- button hover effect: none, glow, size
+    hovereffect = "size",                  -- button hover effect: none, glow, size, color
     hover_button_size = 110,               -- the relative size of a hovered button if the size effect is selected
 
     showjump = true,                       -- show "jump forward/backward 10 seconds" buttons 
@@ -315,7 +316,7 @@ local function set_osc_styles()
         WindowTitle = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.window_title_color) .. "&\\3c&H0&\\fs".. 30 .. "\\q2\\fn" .. user_opts.font .. "}",
         WinCtrl = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.window_controls_color) .. "&\\3c&H0&\\fs".. 25 .. "\\fnmpv-osd-symbols}",
         elementDown = "{\\1c&H" .. osc_color_convert(user_opts.held_element_color) .. "&}",
-        elementHover = "{" .. (user_opts.hovereffect == "glow" and "\\blur5" or "") .. "\\2c&HFFFFFF&" .. (user_opts.hovereffect == "size" and string.format("\\fscx%s\\fscy%s", user_opts.hover_button_size, user_opts.hover_button_size) or "") .. "}",
+        elementHover = "{" .. (user_opts.hovereffect == "glow" and "\\blur5" or "") .. (user_opts.hovereffect == "color" and "\\1c&H" .. osc_color_convert(user_opts.hovereffect_color) or "") .."\\2c&HFFFFFF&" .. (user_opts.hovereffect == "size" and string.format("\\fscx%s\\fscy%s", user_opts.hover_button_size, user_opts.hover_button_size) or "") .. "}",
         wcBar = "{\\1c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
     }
 end
@@ -1005,8 +1006,8 @@ local function render_elements(master_ass)
             end
 
         elseif element.type == "button" then
-            if user_opts.hovereffect == "size" then
-                -- add size hover effect
+            if user_opts.hovereffect == "size" or user_opts.hovereffect == "color" then
+                -- add size and color hover effect
                 local button_lo = element.layout.button
                 local is_clickable = element.eventresponder and (
                     element.eventresponder["mbtn_left_down"] ~= nil or

--- a/modernz.lua
+++ b/modernz.lua
@@ -39,7 +39,7 @@ local user_opts = {
     hovereffect_color = "#CCCCCC",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
-    hovereffect = "size, glow",            -- list of active button hover effects seperated by comma: glow, size, color
+    hovereffect = "size",            -- list of active button hover effects seperated by comma: glow, size, color
     hover_button_size = 110,               -- the relative size of a hovered button if the size effect is active
     button_glow_amount = 5,                -- the amount of glow a hovered button receives if the glow effect is active
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -36,11 +36,12 @@ local user_opts = {
     playpause_color = "#FFFFFF",           -- color of play/pause button
     held_element_color = "#999999",        -- color of an element while held down
     thumbnailborder_color = "#111111",     -- color of border for thumbnail (with thumbfast)
-    hovereffect_color = "#BBBBBB",         -- color of a hovered button when hovereffect is: color
+    hovereffect_color = "#CCCCCC",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
     hovereffect = "size, glow",            -- list of active button hover effects seperated by comma: glow, size, color
-    hover_button_size = 110,               -- the relative size of a hovered button if the size effect is selected
+    hover_button_size = 110,               -- the relative size of a hovered button if the size effect is active
+    button_glow_amount = 5,                -- the amount of glow a hovered button receives if the glow effect is active
 
     showjump = true,                       -- show "jump forward/backward 10 seconds" buttons 
     showskip = false,                      -- show the chapter skip back and forward buttons
@@ -1064,7 +1065,7 @@ local function render_elements(master_ass)
             if hovered and contains(user_opts.hovereffect, "glow") then
                 local shadow_ass = assdraw.ass_new()
                 shadow_ass:merge(style_ass)
-                shadow_ass:append("{\\blur5}" .. button_lo.hoverstyle .. buttontext)
+                shadow_ass:append("{\\blur" .. user_opts.button_glow_amount .. "}" .. button_lo.hoverstyle .. buttontext)
                 elem_ass:merge(shadow_ass)
             end
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -1054,7 +1054,7 @@ local function render_elements(master_ass)
                 element.eventresponder["mbtn_left_down"] ~= nil or
                 element.eventresponder["mbtn_left_up"] ~= nil
             )
-            local hovered = mouse_hit(element) and is_clickable and element.enabled
+            local hovered = mouse_hit(element) and is_clickable and element.enabled and state.mouse_down_counter == 0
             if hovered and (contains(user_opts.hovereffect, "size") or contains(user_opts.hovereffect, "color") or contains(user_opts.hovereffect, "glow")) then
                 elem_ass:append(button_lo.hoverstyle)
             end

--- a/modernz.lua
+++ b/modernz.lua
@@ -36,10 +36,10 @@ local user_opts = {
     playpause_color = "#FFFFFF",           -- color of play/pause button
     held_element_color = "#999999",        -- color of an element while held down
     thumbnailborder_color = "#111111",     -- color of border for thumbnail (with thumbfast)
-    hovereffect_color = "#CCCCCC",         -- color of a hovered button when hovereffect is: color
+    hovereffect_color = "#BBBBBB",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
-    hovereffect = "size",                  -- button hover effect: none, glow, size, color
+    hovereffect = "size, glow",            -- list of active button hover effects seperated by comma: glow, size, color
     hover_button_size = 110,               -- the relative size of a hovered button if the size effect is selected
 
     showjump = true,                       -- show "jump forward/backward 10 seconds" buttons 
@@ -273,6 +273,24 @@ local function set_osc_texts()
     texts = language[user_opts.language] or language["en"]
 end
 
+local function contains(list, item)
+    local t = {}
+    if type(list) ~= "table" then
+        for str in string.gmatch(list, '([^,]+)') do
+            str = str:gsub("%s+", "")
+            table.insert(t, str)
+        end
+    else
+        t = list
+    end
+    for _, v in ipairs(t) do
+        if v == item then
+            return true
+        end
+    end
+    return false
+end
+
 local thumbfast = {
     width = 0,
     height = 0,
@@ -316,7 +334,7 @@ local function set_osc_styles()
         WindowTitle = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.window_title_color) .. "&\\3c&H0&\\fs".. 30 .. "\\q2\\fn" .. user_opts.font .. "}",
         WinCtrl = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.window_controls_color) .. "&\\3c&H0&\\fs".. 25 .. "\\fnmpv-osd-symbols}",
         elementDown = "{\\1c&H" .. osc_color_convert(user_opts.held_element_color) .. "&}",
-        elementHover = "{" .. (user_opts.hovereffect == "glow" and "\\blur5" or "") .. (user_opts.hovereffect == "color" and "\\1c&H" .. osc_color_convert(user_opts.hovereffect_color) or "") .."\\2c&HFFFFFF&" .. (user_opts.hovereffect == "size" and string.format("\\fscx%s\\fscy%s", user_opts.hover_button_size, user_opts.hover_button_size) or "") .. "}",
+        elementHover = "{" .. (contains(user_opts.hovereffect, "color") and "\\1c&H" .. osc_color_convert(user_opts.hovereffect_color) or "") .."\\2c&HFFFFFF&" .. (contains(user_opts.hovereffect, "size") and string.format("\\fscx%s\\fscy%s", user_opts.hover_button_size, user_opts.hover_button_size) or "") .. "}",
         wcBar = "{\\1c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
     }
 end
@@ -1006,18 +1024,6 @@ local function render_elements(master_ass)
             end
 
         elseif element.type == "button" then
-            if user_opts.hovereffect == "size" or user_opts.hovereffect == "color" then
-                -- add size and color hover effect
-                local button_lo = element.layout.button
-                local is_clickable = element.eventresponder and (
-                    element.eventresponder["mbtn_left_down"] ~= nil or
-                    element.eventresponder["mbtn_left_up"] ~= nil
-                )
-                if mouse_hit(element) and is_clickable and element.enabled then
-                    elem_ass:append(button_lo.hoverstyle)
-                end
-            end
-
             local buttontext
             if type(element.content) == "function" then
                 buttontext = element.content() -- function objects
@@ -1041,7 +1047,26 @@ local function render_elements(master_ass)
                 buttontext = string.format("{\\fscx%f}%s{\\r}", stretch, buttontext)
             end
 
+
+            -- add hover effects
+            local button_lo = element.layout.button
+            local is_clickable = element.eventresponder and (
+                element.eventresponder["mbtn_left_down"] ~= nil or
+                element.eventresponder["mbtn_left_up"] ~= nil
+            )
+            local hovered = mouse_hit(element) and is_clickable and element.enabled
+            if hovered and (contains(user_opts.hovereffect, "size") or contains(user_opts.hovereffect, "color") or contains(user_opts.hovereffect, "glow")) then
+                elem_ass:append(button_lo.hoverstyle)
+            end
+            -- add button icon/text
             elem_ass:append(buttontext)
+            -- add blur effect
+            if hovered and contains(user_opts.hovereffect, "glow") then
+                local shadow_ass = assdraw.ass_new()
+                shadow_ass:merge(style_ass)
+                shadow_ass:append("{\\blur5}" .. button_lo.hoverstyle .. buttontext)
+                elem_ass:merge(shadow_ass)
+            end
 
             -- add tooltip for audio and subtitle tracks
             if element.tooltipF ~= nil then
@@ -1076,22 +1101,6 @@ local function render_elements(master_ass)
                     elem_ass:an(an)
                     elem_ass:append(element.tooltip_style)
                     elem_ass:append(tooltiplabel)
-                end
-            end
-
-            if user_opts.hovereffect == "glow" then
-                -- add glow hover effect
-                -- source: https://github.com/Zren/mpvz/issues/13
-                local button_lo = element.layout.button
-                local is_clickable = element.eventresponder and (
-                    element.eventresponder["mbtn_left_down"] ~= nil or
-                    element.eventresponder["mbtn_left_up"] ~= nil
-                )
-                if mouse_hit(element) and is_clickable and element.enabled then
-                    local shadow_ass = assdraw.ass_new()
-                    shadow_ass:merge(style_ass)
-                    shadow_ass:append(button_lo.hoverstyle .. buttontext)
-                    elem_ass:merge(shadow_ass)
                 end
             end
         end

--- a/modernz.lua
+++ b/modernz.lua
@@ -39,7 +39,7 @@ local user_opts = {
     hovereffect_color = "#CCCCCC",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
-    hovereffect = "size",            -- list of active button hover effects seperated by comma: glow, size, color
+    hovereffect = "size,glow,color",       -- list of active button hover effects seperated by comma: glow, size, color
     hover_button_size = 110,               -- the relative size of a hovered button if the size effect is active
     button_glow_amount = 5,                -- the amount of glow a hovered button receives if the glow effect is active
 


### PR DESCRIPTION
This PR adds a new `color` hovereffect (should solve #130) and allows the user to use multiple hovereffects.
It also adds a configuration for the glow amount which should make all hovereffect properties changeable in config.

## Changes
- `hovereffect` is now a comma seperated list with possible values of: `glow`, `size` and `color`
- Added `hovereffect_color` which is the hex color applied when using the `color` hovereffect
- Added `button_glow_amount` which alters the glow/blur applied by the `glow` hovereffect

## Preview
Previews of all hover effects together.

https://github.com/user-attachments/assets/e1b2adbf-67e2-4bec-a311-49083dfb6786

https://github.com/user-attachments/assets/fda194bd-460e-4c86-9f57-82a4fc08786c