### PR TITLE
Add button bar decluttering options (playlist & tooltips)

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -48,6 +48,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | button_glow_amount         | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
 | showplaylist               | no              | show `playlist` button                                                                                                                                        |
 | hide_empty_playlist_button | yes             | hides `playlist` button when a playlist does not exist                                                                                                        |
+| gray_empty_playlist_button | yes             | grays `playlist` button when no playlist exists                                                                                             |
 | showjump                   | yes             | show `jump forward/backward 10 seconds` buttons                                                                                                               |
 | showskip                   | no              | show the `skip back/forward (chapter)` buttons                                                                                                                |
 | shownextprev               | yes             | show the `next/previous playlist track` buttons                                                                                                               |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -41,25 +41,26 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Buttons
 
-| Option                | Value           | Description                                                                                                                                                   |
-| --------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hovereffect           | size,glow,color | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
-| hover_button_size     | 115             | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
-| button_glow_amount    | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
-| showplaylist          | no              | show `playlist` button                                                                                                                                        |
-| showjump              | yes             | show `jump forward/backward 10 seconds` buttons                                                                                                               |
-| showskip              | no              | show the `skip back/forward (chapter)` buttons                                                                                                                |
-| shownextprev          | yes             | show the `next/previous playlist track` buttons                                                                                                               |
-| showinfo              | no              | show the `info (stats)` button                                                                                                                                |
-| showloop              | yes             | show the `loop` button                                                                                                                                        |
-| showfullscreen_button | yes             | show the `fullscreen toggle` button                                                                                                                           |
-| showontop             | yes             | show `window on top (pin)` button                                                                                                                             |
-| showscreenshot        | no              | show `screenshot` button                                                                                                                                      |
-| screenshot_flag       | subtitles       | flag for the screenshot button. `subtitles` `video` `window` `each-frame` [[details](https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)] |
-| chapter_softrepeat    | yes             | holding chapter skip buttons repeats toggle                                                                                                                   |
-| jump_softrepeat       | yes             | holding jump seek buttons repeats toggle                                                                                                                      |
-| downloadbutton        | yes             | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
-| download_path         | ~~desktop/mpv   | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
+| Option                     | Value           | Description                                                                                                                                                   |
+| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| hovereffect                | size,glow,color | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
+| hover_button_size          | 115             | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
+| button_glow_amount         | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
+| showplaylist               | no              | show `playlist` button                                                                                                                                        |
+| hide_empty_playlist_button | yes             | hides `playlist` button when a playlist does not exist                                                                                                        |
+| showjump                   | yes             | show `jump forward/backward 10 seconds` buttons                                                                                                               |
+| showskip                   | no              | show the `skip back/forward (chapter)` buttons                                                                                                                |
+| shownextprev               | yes             | show the `next/previous playlist track` buttons                                                                                                               |
+| showinfo                   | no              | show the `info (stats)` button                                                                                                                                |
+| showloop                   | yes             | show the `loop` button                                                                                                                                        |
+| showfullscreen_button      | yes             | show the `fullscreen toggle` button                                                                                                                           |
+| showontop                  | yes             | show `window on top (pin)` button                                                                                                                             |
+| showscreenshot             | no              | show `screenshot` button                                                                                                                                      |
+| screenshot_flag            | subtitles       | flag for the screenshot button. `subtitles` `video` `window` `each-frame` [[details](https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)] |
+| chapter_softrepeat         | yes             | holding chapter skip buttons repeats toggle                                                                                                                   |
+| jump_softrepeat            | yes             | holding jump seek buttons repeats toggle                                                                                                                      |
+| downloadbutton             | yes             | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
+| download_path              | ~~desktop/mpv   | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
 
 ### Scaling
 
@@ -100,23 +101,25 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### UI [elements]
 
-| Option                   | Value            | Description                                                                |
-| ------------------------ | ---------------- | -------------------------------------------------------------------------- |
-| showtitle                | yes              | show title in OSC (above seekbar)                                          |
-| showwindowtitle          | yes              | show window title in borderless/fullscreen mode                            |
-| showwindowcontrols       | yes              | show window controls (close, min, max) in borderless/fullscreen            |
-| show_chapter_title       | yes              | show chapter title next to timestamp (below seekbar)                       |
-| titleBarStrip            | no               | whether to make the title bar a singular bar instead of a black fade       |
-| title                    | `${media-title}` | title above seekbar. `${media-title}` or `${filename}` (can use `/no-ext`) |
-| font                     | mpv-osd-symbols  | mpv-osd-symbols = default osc font (or the one set in mpv.conf)            |
-| titlefontsize            | 30               | the font size of the title text (above seekbar)                            |
-| chapter_fmt              | Chapter: %s      | chapter print format for seekbar-hover. `no` to disable                    |
-| playpause_size           | 30               | icon size for the play-pause button                                        |
-| midbuttons_size          | 24               | icon size for the middle buttons                                           |
-| sidebuttons_size         | 24               | icon size for the side buttons                                             |
-| persistentprogress       | no               | always show a small progress line at the bottom of the screen              |
-| persistentprogressheight | 17               | the height of the persistentprogress bar                                   |
-| persistentbuffer         | no               | on web videos, show the buffer on the persistent progress line             |
+| Option                          | Value            | Description                                                                |
+| ------------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| showtitle                       | yes              | show title in OSC (above seekbar)                                          |
+| showwindowtitle                 | yes              | show window title in borderless/fullscreen mode                            |
+| showwindowcontrols              | yes              | show window controls (close, min, max) in borderless/fullscreen            |
+| show_chapter_title              | yes              | show chapter title next to timestamp (below seekbar)                       |
+| titleBarStrip                   | no               | whether to make the title bar a singular bar instead of a black fade       |
+| title                           | `${media-title}` | title above seekbar. `${media-title}` or `${filename}` (can use `/no-ext`) |
+| font                            | mpv-osd-symbols  | mpv-osd-symbols = default osc font (or the one set in mpv.conf)            |
+| titlefontsize                   | 30               | the font size of the title text (above seekbar)                            |
+| chapter_fmt                     | Chapter: %s      | chapter print format for seekbar-hover. `no` to disable                    |
+| tooltips_for_disabled_elements  | yes              | enables tooltips for disabled buttons and elements                         |
+| tooltip_hints                   | yes              | enables text hints for the information, loop, ontop and screenshot buttons |
+| playpause_size                  | 30               | icon size for the play-pause button                                        |
+| midbuttons_size                 | 24               | icon size for the middle buttons                                           |
+| sidebuttons_size                | 24               | icon size for the side buttons                                             |
+| persistentprogress              | no               | always show a small progress line at the bottom of the screen              |
+| persistentprogressheight        | 17               | the height of the persistentprogress bar                                   |
+| persistentbuffer                | no               | on web videos, show the buffer on the persistent progress line             |
 
 ### UI [behavior]
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -50,6 +50,8 @@ button_glow_amount=5
 showplaylist=no
 # hide playlist button when no playlist exists
 hide_empty_playlist_button=yes
+# grays out the playlist button when no playlist exists
+gray_empty_playlist_button=yes
 # show "jump forward/backward 10 seconds" buttons 
 showjump=yes
 # show the skip back and forward (chapter) buttons

--- a/modernz.conf
+++ b/modernz.conf
@@ -48,6 +48,8 @@ hover_button_size=115
 button_glow_amount=5
 # show playlist button
 showplaylist=no
+# hide playlist button when no playlist exists
+hide_empty_playlist_button=yes
 # show "jump forward/backward 10 seconds" buttons 
 showjump=yes
 # show the skip back and forward (chapter) buttons

--- a/modernz.conf
+++ b/modernz.conf
@@ -143,6 +143,10 @@ font=mpv-osd-symbols
 titlefontsize=30
 # chapter print format for seekbar-hover. "no" to disable
 chapter_fmt=Chapter: %s
+# enables tooltips for disabled buttons and elements
+tooltips_for_disabled_elements=yes
+# enables text hints for the information, loop, ontop and screenshot buttons
+tooltip_hints=yes
 # always show a small progress line at the bottom of the screen
 persistentprogress=no
 # the height of the persistentprogress bar

--- a/modernz.lua
+++ b/modernz.lua
@@ -48,6 +48,7 @@ local user_opts = {
     shownextprev = true,                   -- show the next/previous playlist track buttons
 
     showplaylist = false,                  -- show playlist button? LClick: simple playlist, RClick: interactive playlist
+    hide_empty_playlist_button = true,     -- hide playlist button when no playlist exists
     showinfo = false,                      -- show the info button
     showloop = true,                       -- show the loop button
     showfullscreen_button = true,          -- show fullscreen toggle button
@@ -1532,7 +1533,7 @@ layouts = function ()
     local showinfo = user_opts.showinfo
     local showontop = user_opts.showontop
     local showscreenshot = user_opts.showscreenshot
-    local showplaylist = user_opts.showplaylist
+    local showplaylist = user_opts.showplaylist and (not user_opts.hide_empty_playlist_button or mp.get_property_number("playlist-count", 0) > 1)
 
     local offset = showjump and 60 or 0
     local outeroffset = (showskip and 0 or 100) + (showjump and 0 or 100)

--- a/modernz.lua
+++ b/modernz.lua
@@ -1778,9 +1778,9 @@ local function osc_init()
 
     -- some often needed stuff
     local pl_count = mp.get_property_number("playlist-count", 0)
-    local have_pl = (pl_count > 1)
+    local have_pl = pl_count > 1
     local pl_pos = mp.get_property_number("playlist-pos", 0) + 1
-    local have_ch = (mp.get_property_number("chapters", 0) > 0)
+    local have_ch = mp.get_property_number("chapters", 0) > 0
     local loop = mp.get_property("loop-playlist", "no")
 
     local nojumpoffset = user_opts.showjump and 0 or 100
@@ -1934,7 +1934,7 @@ local function osc_init()
     --tog_playlist
     ne = new_element("tog_playlist", "button")
     ne.enabled = have_pl or not user_opts.gray_empty_playlist_button
-    ne.off = have_pl and user_opts.gray_empty_playlist_button
+    ne.off = not have_pl and user_opts.gray_empty_playlist_button
     ne.visible = (osc_param.playresx >= 700 - outeroffset)
     ne.content = icons.playlist
     ne.tooltip_style = osc_styles.tooltip

--- a/modernz.lua
+++ b/modernz.lua
@@ -103,6 +103,9 @@ local user_opts = {
     titlefontsize = 30,                    -- the font size of the title text (above seekbar)
     chapter_fmt = "%s",                    -- chapter print format for seekbar-hover. "no" to disable
 
+    tooltips_for_disabled_elements = true, -- enables tooltips for disabled buttons and elements
+    tooltip_hints = true,                  -- enables text hints for the information, loop, ontop and screenshot buttons
+
     playpause_size = 30,                   -- icon size for the play-pause button
     midbuttons_size = 24,                  -- icon size for the middle buttons
     sidebuttons_size = 24,                 -- icon size for the side buttons
@@ -1070,7 +1073,7 @@ local function render_elements(master_ass)
             end
 
             -- add tooltip for audio and subtitle tracks
-            if element.tooltipF ~= nil then
+            if element.tooltipF ~= nil and (user_opts.tooltips_for_disabled_elements or element.enabled) then
                 if mouse_hit(element) then
                     local tooltiplabel = element.tooltipF
                     local an = 1
@@ -2007,7 +2010,9 @@ local function osc_init()
     ne = new_element("tog_info", "button")
     ne.content = icons.info
     ne.tooltip_style = osc_styles.Tooltip
-    ne.tooltipF = texts.statsinfo
+    if user_opts.tooltip_hints then
+        ne.tooltipF = texts.statsinfo
+    end
     ne.visible = (osc_param.playresx >= 600 - outeroffset - (user_opts.showfullscreen and 0 or 100))
     ne.eventresponder["mbtn_left_up"] = function () mp.commandv("script-binding", "stats/display-stats-toggle") end
 
@@ -2016,7 +2021,9 @@ local function osc_init()
     ne.content = function () return state.looping and icons.loop_on or icons.loop_off end
     ne.visible = (osc_param.playresx >= 700 - outeroffset - (user_opts.showinfo and 0 or 100) - (user_opts.showfullscreen and 0 or 100))
     ne.tooltip_style = osc_styles.Tooltip
-    ne.tooltipF = function () return state.looping and texts.loopdisable or texts.loopenable end
+    if user_opts.tooltip_hints then
+        ne.tooltipF = function () return state.looping and texts.loopdisable or texts.loopenable end
+    end
     ne.eventresponder["mbtn_left_up"] = function ()
         if state.looping then
             mp.command("show-text '" .. texts.loopdisable .. "'")
@@ -2031,7 +2038,9 @@ local function osc_init()
     ne = new_element("tog_ontop", "button")
     ne.content = function () return mp.get_property("ontop") == "no" and icons.ontop_on or icons.ontop_off end
     ne.tooltip_style = osc_styles.Tooltip
-    ne.tooltipF = function () return mp.get_property("ontop") == "no" and texts.ontop or texts.ontopdisable end
+    if user_opts.tooltip_hints then
+        ne.tooltipF = function () return mp.get_property("ontop") == "no" and texts.ontop or texts.ontopdisable end
+    end
     ne.visible = (osc_param.playresx >= 760 - outeroffset - (user_opts.showloop and 0 or 100) - (user_opts.showinfo and 0 or 100) - (user_opts.showfullscreen and 0 or 100))
     ne.eventresponder["mbtn_left_up"] = function () 
         mp.commandv("cycle", "ontop") 
@@ -2054,7 +2063,9 @@ local function osc_init()
     ne = new_element("screenshot", "button")
     ne.content = icons.screenshot
     ne.tooltip_style = osc_styles.Tooltip
-    ne.tooltipF = texts.screenshot
+    if user_opts.tooltip_hints then
+        ne.tooltipF = texts.screenshot
+    end
     ne.visible = (osc_param.playresx >= 870 - outeroffset - (user_opts.showontop and 0 or 100) - (user_opts.showloop and 0 or 100) - (user_opts.showinfo and 0 or 100) - (user_opts.showfullscreen and 0 or 100))
     ne.eventresponder["mbtn_left_up"] = function ()
         local tempSubPosition = mp.get_property("sub-pos")

--- a/modernz.lua
+++ b/modernz.lua
@@ -49,6 +49,7 @@ local user_opts = {
 
     showplaylist = false,                  -- show playlist button? LClick: simple playlist, RClick: interactive playlist
     hide_empty_playlist_button = true,     -- hide playlist button when no playlist exists
+    gray_empty_playlist_button = true,     -- grays out the playlist button when no playlist exists
     showinfo = false,                      -- show the info button
     showloop = true,                       -- show the loop button
     showfullscreen_button = true,          -- show fullscreen toggle button
@@ -800,7 +801,7 @@ local function prepare_elements()
         -- style it accordingly and kill the eventresponders
         if not element.enabled then
             element.layout.alpha[1] = 215
-            if not (element.name == "sub_track" or element.name == "audio_track") then -- keep these to display tooltips
+            if not (element.name == "sub_track" or element.name == "audio_track" or element.name == "tog_playlist") then -- keep these to display tooltips
                 element.eventresponder = nil
             end
         end
@@ -1932,10 +1933,13 @@ local function osc_init()
 
     --tog_playlist
     ne = new_element("tog_playlist", "button")
+    ne.enabled = have_pl or not user_opts.gray_empty_playlist_button
+    ne.off = have_pl and user_opts.gray_empty_playlist_button
     ne.visible = (osc_param.playresx >= 700 - outeroffset)
     ne.content = icons.playlist
     ne.tooltip_style = osc_styles.Tooltip
     ne.tooltipF = pl_count > 0 and texts.playlist .. " [" .. pl_pos .. "/" .. pl_count .. "]" or texts.playlist
+    ne.nothingavailable = texts.nolist
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.playlist_mbtn_left_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.playlist_mbtn_right_command)
 


### PR DESCRIPTION
This PR adds button bar decluttering options for the playlist button and tooltips.
## Changes
- Added `hide_empty_playlist_button` which hides the playlist button when no playlist exists.
- Added `gray_empty_playlist_button` which grays out the playlist button when no playlist exists. Which should solve #129.
- Added `tooltips_for_disabled_elements` which disables tooltips for disabled/grayed out buttons. E.g. the sub track button when no subtitles are available.
- Added `tooltip_hints` which toggles the clarification tooltips of the information, loop, ontop and screenshot buttons.