### PR TITLE
refactor: apply all hover effects by default, except for size, limit it

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -39,6 +39,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | playpause_color       | #FFFFFF | color of play/pause button                                               |
 | held_element_color    | #999999 | color of an element while held down                                      |
 | thumbnailborder_color | #111111 | color of border for thumbnail (with thumbfast)                           |
+| hovereffect_color     | #CB7050 | color of a hovered button when hovereffect includes: `color`             |
 
 ### Buttons
 
@@ -47,7 +48,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | hovereffect                | size,glow,color | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
 | hover_button_size          | 115             | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
 | button_glow_amount         | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
-| hovereffect_for_sliders    | no              | apply button hovereffects to slide handles                                                                                                                    |
+| hovereffect_for_sliders    | yes             | apply button hovereffects to slide handles                                                                                                                    |
 | showplaylist               | no              | show `playlist` button                                                                                                                                        |
 | hide_empty_playlist_button | yes             | hides `playlist` button when a playlist does not exist                                                                                                        |
 | gray_empty_playlist_button | yes             | grays `playlist` button when no playlist exists                                                                                                               |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -69,7 +69,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 ### Scaling
 
 | Option            | Value | Description                                                     |
-| ----------------- | ----- | ----------------------------------------------                  |
+| ----------------- | ----- | --------------------------------------------------------------- |
 | vidscale          | auto  | whether to scale the controller with the video. `no` to disable |
 | scalewindowed     | 1.0   | scaling of the controller when windowed                         |
 | scalefullscreen   | 1.0   | scaling of the controller when fullscreen                       |
@@ -77,7 +77,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 ### Time & Volume
 
 | Option            | Value    | Description                                                                      |
-| ----------------- | -------- | ---------------------------------------------------------------------------------|
+| ----------------- | -------- | -------------------------------------------------------------------------------- |
 | unicodeminus      | no       | whether to use the Unicode minus sign character in remaining time                |
 | timetotal         | yes      | display total time instead of remaining time?                                    |
 | timems            | no       | display timecodes with milliseconds                                              |
@@ -105,26 +105,26 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### UI [elements]
 
-| Option                          | Value            | Description                                                                         |
-| ------------------------------- | ---------------- | ----------------------------------------------------------------------------------- |
-| showtitle                       | yes              | show title in OSC (above seekbar)                                                   |
-| showwindowtitle                 | yes              | show window title in borderless/fullscreen mode                                     |
-| showwindowcontrols              | yes              | show window controls (close, min, max) in borderless/fullscreen                     |
-| show_chapter_title              | yes              | show chapter title next to timestamp (below seekbar)                                |
-| titleBarStrip                   | no               | whether to make the title bar a singular bar instead of a black fade                |
-| title                           | `${media-title}` | title above seekbar                                                                 |
-| windowcontrols_title            | `${media-title}` | title in windowcontrols                                                             |
-| font                            | mpv-osd-symbols  | mpv-osd-symbols = default osc font (or the one set in mpv.conf)                     |
-| titlefontsize                   | 30               | the font size of the title text (above seekbar)                                     |
-| chapter_fmt                     | %s               | chapter print format for seekbar-hover. `no` to disable                             |
-| tooltips_for_disabled_elements  | yes              | enables tooltips for disabled buttons and elements                                  |
-| tooltip_hints                   | yes              | enables text hints for the information, loop, ontop and screenshot buttons          |
-| playpause_size                  | 30               | icon size for the play-pause button                                                 |
-| midbuttons_size                 | 24               | icon size for the middle buttons                                                    |
-| sidebuttons_size                | 24               | icon size for the side buttons                                                      |
-| persistentprogress              | no               | always show a small progress line at the bottom of the screen                       |
-| persistentprogressheight        | 17               | the height of the persistentprogress bar                                            |
-| persistentbuffer                | no               | on web videos, show the buffer on the persistent progress line                      |
+| Option                          | Value            | Description                                                                |
+| ------------------------------- | ---------------- | -------------------------------------------------------------------------- |
+| showtitle                       | yes              | show title in OSC (above seekbar)                                          |
+| showwindowtitle                 | yes              | show window title in borderless/fullscreen mode                            |
+| showwindowcontrols              | yes              | show window controls (close, min, max) in borderless/fullscreen            |
+| show_chapter_title              | yes              | show chapter title next to timestamp (below seekbar)                       |
+| titleBarStrip                   | no               | whether to make the title bar a singular bar instead of a black fade       |
+| title                           | `${media-title}` | title above seekbar                                                        |
+| windowcontrols_title            | `${media-title}` | title in windowcontrols                                                    |
+| font                            | mpv-osd-symbols  | mpv-osd-symbols = default osc font (or the one set in mpv.conf)            |
+| titlefontsize                   | 30               | the font size of the title text (above seekbar)                            |
+| chapter_fmt                     | %s               | chapter print format for seekbar-hover. `no` to disable                    |
+| tooltips_for_disabled_elements  | yes              | enables tooltips for disabled buttons and elements                         |
+| tooltip_hints                   | yes              | enables text hints for the information, loop, ontop and screenshot buttons |
+| playpause_size                  | 30               | icon size for the play-pause button                                        |
+| midbuttons_size                 | 24               | icon size for the middle buttons                                           |
+| sidebuttons_size                | 24               | icon size for the side buttons                                             |
+| persistentprogress              | no               | always show a small progress line at the bottom of the screen              |
+| persistentprogressheight        | 17               | the height of the persistentprogress bar                                   |
+| persistentbuffer                | no               | on web videos, show the buffer on the persistent progress line             |
 
 ### UI [behavior]
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -38,7 +38,7 @@ playpause_color=#FFFFFF
 # color of an element while held down
 held_element_color=#999999
 # color of a hovered button when hovereffect is: color
-hovereffect_color=#CCCCCC
+hovereffect_color=#CB7050
 
 ## Buttons
 # list of active button hover effects seperated by comma: glow, size, color
@@ -49,7 +49,7 @@ hover_button_size=115
 # the amount of glow a hovered button receives if the glow effect is active
 button_glow_amount=5
 # apply button hovereffects to slide handles
-hovereffect_for_sliders=no
+hovereffect_for_sliders=yes
 # show playlist button
 showplaylist=no
 # hide playlist button when no playlist exists

--- a/modernz.conf
+++ b/modernz.conf
@@ -37,7 +37,9 @@ middle_buttons_color=#FFFFFF
 playpause_color=#FFFFFF
 # color of an element while held down
 held_element_color=#999999
-# color of a hovered button when hovereffect is: color
+color of border for thumbnail (with thumbfast)
+thumbnailborder_color=#111111
+# color of a hovered button when hovereffect includes: color
 hovereffect_color=#CB7050
 
 ## Buttons

--- a/modernz.lua
+++ b/modernz.lua
@@ -39,8 +39,8 @@ local user_opts = {
     hovereffect_color = "#CB7050",         -- color of a hovered button when hovereffect is: color
 
     -- Buttons
-    hovereffect = "glow,color",            -- list of active button hover effects seperated by comma: glow, size, color
-    hover_button_size = 110,               -- the relative size of a hovered button if the size effect is active
+    hovereffect = "size,glow,color",       -- list of active button hover effects seperated by comma: glow, size, color
+    hover_button_size = 115,               -- the relative size of a hovered button if the size effect is active
     button_glow_amount = 5,                -- the amount of glow a hovered button receives if the glow effect is active
     hovereffect_for_sliders = true,        -- apply button hovereffects to slide handles
 
@@ -1070,7 +1070,6 @@ local function render_elements(master_ass)
                 buttontext = string.format("{\\fscx%f}%s{\\r}", stretch, buttontext)
             end
 
-
             -- add hover effects
             local button_lo = element.layout.button
             local is_clickable = element.eventresponder and (
@@ -1078,16 +1077,22 @@ local function render_elements(master_ass)
                 element.eventresponder["mbtn_left_up"] ~= nil
             )
             local hovered = mouse_hit(element) and is_clickable and element.enabled and state.mouse_down_counter == 0
+            local hoverstyle = button_lo.hoverstyle
             if hovered and (contains(user_opts.hovereffect, "size") or contains(user_opts.hovereffect, "color") or contains(user_opts.hovereffect, "glow")) then
-                elem_ass:append(button_lo.hoverstyle)
+                -- remove font scale tags for these elements, it looks out of place
+                if element.name == "title" or element.name == "tc_left" or element.name == "tc_right" or element.name == "chapter_title" then
+                    hoverstyle = hoverstyle:gsub("\\fscx%d+\\fscy%d+", "")
+                end
+                elem_ass:append(hoverstyle .. buttontext)
+            else
+                elem_ass:append(buttontext)
             end
-            -- add button icon/text
-            elem_ass:append(buttontext)
-            -- add blur effect
+
+            -- apply blur effect if "glow" is in hover effects
             if hovered and contains(user_opts.hovereffect, "glow") then
                 local shadow_ass = assdraw.ass_new()
                 shadow_ass:merge(style_ass)
-                shadow_ass:append("{\\blur" .. user_opts.button_glow_amount .. "}" .. button_lo.hoverstyle .. buttontext)
+                shadow_ass:append("{\\blur" .. user_opts.button_glow_amount .. "}" .. hoverstyle .. buttontext)
                 elem_ass:merge(shadow_ass)
             end
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -1078,7 +1078,7 @@ local function render_elements(master_ass)
             )
             local hovered = mouse_hit(element) and is_clickable and element.enabled and state.mouse_down_counter == 0
             local hoverstyle = button_lo.hoverstyle
-            if hovered and (contains(user_opts.hovereffect, "size") or contains(user_opts.hovereffect, "color") or contains(user_opts.hovereffect, "glow")) then
+            if hovered and (contains(user_opts.hovereffect, "size") or contains(user_opts.hovereffect, "color")) then
                 -- remove font scale tags for these elements, it looks out of place
                 if element.name == "title" or element.name == "tc_left" or element.name == "tc_right" or element.name == "chapter_title" then
                     hoverstyle = hoverstyle:gsub("\\fscx%d+\\fscy%d+", "")


### PR DESCRIPTION
Pinging: @Commander07 @Keith94 

**Note:** This isn't mandotary, because I realize personal preference is a factor. That is why I decided not to merge but to first consult with you guys. (original PR maker and requester)

The hover effect size looks great on all elements, except for the following: (looks out of place)
- Title (above seekbar)
- Timestamps (left and right)
- Chapter title (below seekbar)

The size hover effect will be stripped from them.

**Other changes:**
- Tie `elem_ass:append()` to a nested condition, to ensure single action. (ie: in title, it was appending twice, hover and text)
- Restore default value for `hover_button_size` to `115` instead of `110`
- Apply all effects in `hovereffect`
- Change `hovereffect_color` to `#CB7050`, a slightly brighter match with the default seekbar color.
- Remove redundant  `or contains(user_opts.hovereffect, "glow")` condition, as it is applied/checked below it already.

**Preview:**

https://github.com/user-attachments/assets/f90439d5-fae3-48b1-b881-4f31a558b721
