### PR TITLE
feat: disable irrelevant elements for images

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -100,6 +100,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | playpause_size             | 30            | icon size for the play/pause button                                                                                                                                                                    |
 | midbuttons_size            | 24            | icon size for the middle buttons                                                                                                                                                                       |
 | sidebuttons_size           | 24            | icon size for the side buttons                                                                                                                                                                         |
+| hide_elements_for_image    | yes           | hides irrelevant elements when viewing images                                                                                                                                                          |
 
 ### Colors and style
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -169,6 +169,8 @@ persistentprogress=no
 persistentprogressheight=17
 # on web videos, show the buffer on the persistent progress line
 persistentbuffer=no
+# hides irrelevant elements when viewing images
+hide_elements_for_image=yes
 
 ## UI [behavior]
 # whether to show osc when paused

--- a/modernz.lua
+++ b/modernz.lua
@@ -983,7 +983,7 @@ local function render_elements(master_ass)
                 elem_ass:draw_stop()
                 
                 -- add tooltip
-                if element.slider.tooltipF ~= nil then
+                if element.slider.tooltipF ~= nil and element.enabled then
                     if mouse_hit(element) then
                         local sliderpos = get_slider_value(element)
                         local tooltiplabel = element.slider.tooltipF(sliderpos)
@@ -1863,6 +1863,7 @@ local function osc_init()
     local pl_pos = mp.get_property_number("playlist-pos", 0) + 1
     local have_ch = mp.get_property_number("chapters", 0) > 0
     local loop = mp.get_property("loop-playlist", "no")
+    local is_image = mp.get_property_number("estimated-frame-count", 0) < 2 and audio_track_count == 0
 
     local nojumpoffset = user_opts.showjump and 0 or 100
     local noskipoffset = user_opts.showskip and 0 or 100
@@ -1903,6 +1904,7 @@ local function osc_init()
     --play control buttons
     --play_pause
     ne = new_element("play_pause", "button")
+    ne.enabled = not is_image
     ne.content = function ()
         if mp.get_property("eof-reached") == "yes" then
             return icons.replay
@@ -1936,6 +1938,7 @@ local function osc_init()
 
     --jump_backward
     ne = new_element("jump_backward", "button")
+    ne.enabled = not is_image
     ne.softrepeat = user_opts.jump_softrepeat == true
     ne.content = jump_icon[1]
     ne.eventresponder["mbtn_left_down"] = function () mp.commandv("seek", -jumpamount, jumpmode) end
@@ -1944,6 +1947,7 @@ local function osc_init()
 
     --jump_forward
     ne = new_element("jump_forward", "button")
+    ne.enabled = not is_image
     ne.softrepeat = user_opts.jump_softrepeat == true
     ne.content = jump_icon[2]
     ne.eventresponder["mbtn_left_down"] = function () mp.commandv("seek", jumpamount, jumpmode) end
@@ -2106,6 +2110,7 @@ local function osc_init()
 
     --tog_loop
     ne = new_element("tog_loop", "button")
+    ne.enabled = not is_image
     ne.content = function () return state.looping and icons.loop_on or icons.loop_off end
     ne.visible = (osc_param.playresx >= 750 - outeroffset - (user_opts.showinfo and 0 or 100) - (user_opts.showfullscreen and 0 or 100))
     ne.tooltip_style = osc_styles.tooltip
@@ -2149,6 +2154,7 @@ local function osc_init()
 
     --screenshot
     ne = new_element("screenshot", "button")
+    ne.enabled = not is_image
     ne.content = icons.screenshot
     ne.tooltip_style = osc_styles.tooltip
     if user_opts.tooltip_hints then
@@ -2204,7 +2210,7 @@ local function osc_init()
 
     --seekbar
     ne = new_element("seekbar", "slider")
-    ne.enabled = mp.get_property("percent-pos") ~= nil
+    ne.enabled = mp.get_property("percent-pos") ~= nil and not is_image
     ne.thumbnailable = true
     state.slider_element = ne.enabled and ne or nil  -- used for forced_title
     ne.slider.markerF = function ()
@@ -2409,6 +2415,7 @@ local function osc_init()
 
     -- Current position time display
     ne = new_element("tc_left", "button")
+    ne.enabled = not is_image
     ne.content = function()
         local playback_time = mp.get_property_number("playback-time", 0)
         return format_time(playback_time)
@@ -2441,6 +2448,7 @@ local function osc_init()
 
     -- Total/remaining time display
     ne = new_element("tc_right", "button")
+    ne.enabled = not is_image
     ne.visible = (mp.get_property_number("duration", 0) > 0)
     ne.content = function()
         local duration = mp.get_property_number("duration", 0)

--- a/modernz.lua
+++ b/modernz.lua
@@ -927,7 +927,7 @@ local function render_elements(master_ass)
                 
                 if pos then
                     xp = get_slider_ele_pos_for(element, pos)
-                    local handle_hovered = mouse_hit_coords(element.hitbox.x1+xp-rh, element.hitbox.y1+elem_geo.h/2-rh, element.hitbox.x1+xp+rh, element.hitbox.y1+elem_geo.h/2+rh)
+                    local handle_hovered = mouse_hit_coords(element.hitbox.x1+xp-rh, element.hitbox.y1+elem_geo.h/2-rh, element.hitbox.x1+xp+rh, element.hitbox.y1+elem_geo.h/2+rh) and element.enabled
                     if handle_hovered and user_opts.hovereffect_for_sliders then
                         -- apply size & color hovereffects (glow is not supported)
                         if contains(user_opts.hovereffect, "size") then
@@ -938,7 +938,7 @@ local function render_elements(master_ass)
                         end
                     end
                     ass_draw_cir_cw(elem_ass, xp, elem_geo.h/2, rh)
-                    if handle_hovered and user_opts.hovereffect_for_sliders  then
+                    if handle_hovered and user_opts.hovereffect_for_sliders then
                         elem_ass:draw_stop()
                         elem_ass:merge(element.style_ass)
                         ass_append_alpha(elem_ass, element.layout.alpha, 0)

--- a/modernz.lua
+++ b/modernz.lua
@@ -1634,7 +1634,7 @@ layouts = function ()
     lo.style = string.format("%s{\\clip(0,%f,%f,%f)}", osc_styles.title,
                              geo.y - geo.h, geo.x + geo.w, geo.y + geo.h)
     lo.alpha[3] = 0
-    lo.button.maxchars = geo.w / 11
+    lo.button.maxchars = geo.w / (should_show and 11 or 25)
 
     -- buttons
     if shownextprev then

--- a/modernz.lua
+++ b/modernz.lua
@@ -2202,10 +2202,10 @@ local function osc_init()
                 local command = {
                     "yt-dlp",
                     ytdl_format,
-                    "--remux", "mp4",
+                    is_image and "" or "--remux", is_image and "" or "mp4",
                     "--add-metadata",
                     "--embed-subs",
-                    "-o", "%(title)s",
+                    "-o", "%(title)s.%(ext)s",
                     "-P", localpath,
                     state.web_video_path
                 }

--- a/modernz.lua
+++ b/modernz.lua
@@ -1871,7 +1871,8 @@ local function osc_init()
     local pl_pos = mp.get_property_number("playlist-pos", 0) + 1
     local have_ch = mp.get_property_number("chapters", 0) > 0
     local loop = mp.get_property("loop-playlist", "no")
-    local is_image = mp.get_property_number("estimated-frame-count", 0) < 2 and audio_track_count == 0
+    local current_track = mp.get_property_native("current-tracks/video")
+    local is_image = current_track and current_track.image and not current_track.albumart and mp.get_property_number("estimated-frame-count", 0) < 2 and audio_track_count == 0
 
     local nojumpoffset = user_opts.showjump and 0 or 100
     local noskipoffset = user_opts.showskip and 0 or 100


### PR DESCRIPTION
## Changes
- Disables irrelevant elements (play/pause, jump, loop, screenshot, seekbar and time display) for images.
- Removes hover effects from disabled sliders to match button behavior.
- Adds `hide_elements_for_image` which when enabled will hide irrelevant elements for images