### PR TITLE
docs: reorder user options and improve comments for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Don't like the default white buttons and text? ModernZ is fully customizable! Ch
 
 ![modernz-colors-bottom](https://github.com/user-attachments/assets/6d686c53-843b-46f9-b630-a396e88b95be)
 
-See the [Color Customization](docs/USER_OPTS.md#colors) section in the configuration guide for details on how to customize colors and buttons.
+See the [Color Customization](docs/USER_OPTS.md#colors-and-style) section in the configuration guide for details on how to customize colors and buttons.
 
 ## Installation
 
 1. **Disable Stock OSC**
+
    - Add `osc=no` in your `mpv.conf`
 
 2. **Copy Files**
@@ -72,7 +73,7 @@ See the [Color Customization](docs/USER_OPTS.md#colors) section in the configura
 
 1. Create `modernz.conf` in the `/script-opts` folder to customize settings
 
-   - [Download default modernz.conf](https://github.com/Samillion/ModernZ/blob/main/modernz.conf)
+   - [Download default modernz.conf](./modernz.conf)
 
 2. Example short configuration:
 
@@ -188,7 +189,8 @@ For even more useful scripts, check out the [mpv User Scripts Wiki](https://gith
     - forked from [maoiscat/mpv-osc-modern](https://github.com/maoiscat/mpv-osc-modern)
 
 **Why fork yet again?**
-- To add many features in: [Color Customization](docs/USER_OPTS.md#colors), [Options](docs/USER_OPTS.md) and [Locale Integration](docs/TRANSLATIONS.md)
+
+- To add many features in: [Color Customization](docs/USER_OPTS.md#colors-and-style), [Options](docs/USER_OPTS.md) and [Locale Integration](docs/TRANSLATIONS.md)
 - To integrate console and select into the osc, which inspired mpv to apply it in the stock osc. [ref [#1](https://github.com/mpv-player/mpv/pull/15016), [#2](https://github.com/mpv-player/mpv/pull/15031)]
 - To re-do the project entirely to match mpv's stock osc standards, to ensure compatibility
 - To eliminate old bugs and redundancy within the code
@@ -198,4 +200,5 @@ In essence, to modernize and revive the `Modern` origin.
 Having said that, ModernZ still uses parts of the old code, and every previous and current fork author and contributor deserve credit (including mpv's stock osc), that is why they're mentioned in detail.
 
 #### Credits:
+
 Fluent System Icons font was modified by [Xurdejl](https://github.com/Xurdejl) for use on ModernZ, they also contributed with code, reports and tests. 😻

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -10,149 +10,159 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ## Available Options
 
-### General
+### Language and display
 
-| Option         | Value | Description                                                                                                    |
-| -------------- | ----- | -------------------------------------------------------------------------------------------------------------- |
-| language       | en    | See [TRANSLATIONS.md](https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md) for other languages |
-| idlescreen     | yes   | show mpv logo on idle                                                                                          |
-| windowcontrols | auto  | whether to show OSC window controls. `auto`, `yes`, `no`                                                       |
-| showwindowed   | yes   | show OSC when windowed                                                                                         |
-| showfullscreen | yes   | show OSC when fullscreen                                                                                       |
-| greenandgrumpy | no    | disable santa hat in December                                                                                  |
+| Option         | Value           | Description                                                                                                                    |
+| -------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| language       | en              | set language (for available options, see: [Translations](https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md)) |
+| font           | mpv-osd-symbols | font for the OSC (default: mpv-osd-symbols or the one set in mpv.conf)                                                         |
+| idlescreen     | yes             | show mpv logo when idle                                                                                                        |
+| windowcontrols | auto            | show OSC window controls: `"auto"`, `"yes"`, or `"no"`                                                                         |
+| showwindowed   | yes             | show OSC when windowed                                                                                                         |
+| showfullscreen | yes             | show OSC when fullscreen                                                                                                       |
+| showonpause    | yes             | show OSC when paused                                                                                                           |
+| keeponpause    | yes             | disable OSC hide timeout when paused                                                                                           |
+| greenandgrumpy | no              | disable Santa hat in December                                                                                                  |
 
-### Colors
+### OSC behaviour and scaling
 
-| Option                | Value   | Description                                                              |
-| --------------------- | ------- | ------------------------------------------------------------------------ |
-| osc_color             | #000000 | accent of the OSC and the title bar                                      |
-| window_title_color    | #FFFFFF | color of title in borderless/fullscreen mode                             |
-| window_controls_color | #FFFFFF | color of window controls (close, min, max) in borderless/fullscreen mode |
-| seekbarfg_color       | #BE4D25 | color of the seekbar progress and handle                                 |
-| seekbarbg_color       | #FFFFFF | color of the remaining seekbar                                           |
-| seekbar_cache_color   | #BF9B24 | color of the cache ranges on the seekbar                                 |
-| vol_bar_match_seek    | no      | match volume bar color with seekbar color? ignores `side_buttons_color`  |
-| title_color           | #FFFFFF | color of the title (above seekbar)                                       |
-| time_color            | #FFFFFF | color of timestamps (below seekbar)                                      |
-| chapter_title_color   | #FFFFFF | color of chapter title next to timestamp (below seekbar)                 |
-| side_buttons_color    | #FFFFFF | color of side buttons (audio, sub, playlist, vol, loop, info..etc)       |
-| middle_buttons_color  | #FFFFFF | color of middle buttons (skip, jump, chapter...etc)                      |
-| playpause_color       | #FFFFFF | color of play/pause button                                               |
-| held_element_color    | #999999 | color of an element while held down                                      |
-| thumbnailborder_color | #111111 | color of border for thumbnail (with thumbfast)                           |
-| hovereffect_color     | #CB7050 | color of a hovered button when hovereffect includes: `color`             |
+| Option                  | Value | Description                                                |
+| ----------------------- | ----- | ---------------------------------------------------------- |
+| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement         |
+| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                    |
+| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade        |
+| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC    |
+| bottomhover             | yes   | show OSC only when hovering at the bottom                  |
+| bottomhover_zone        | 160   | height of hover zone for bottomhover (in pixels)           |
+| osc_on_seek             | no    | show OSC when seeking                                      |
+| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold) |
+| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)       |
+| scalewindowed           | 1.0   | osc scale factor when windowed                             |
+| scalefullscreen         | 1.0   | osc scale factor when fullscreen                           |
 
-### Buttons
+### Time and title display
 
-| Option                     | Value           | Description                                                                                                                                                   |
-| -------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| hovereffect                | size,glow,color | list of active button hover effects seperated by comma: glow, size, color. Ex. `hovereffect=glow, size, color`                                                |
-| hover_button_size          | 115             | the relative size (%) of a hovered button if the size effect is selected                                                                                      |
-| button_glow_amount         | 5               | the amount of glow a hovered button receives if the glow effect is active                                                                                     |
-| hovereffect_for_sliders    | yes             | apply button hovereffects to slide handles                                                                                                                    |
-| showplaylist               | no              | show `playlist` button                                                                                                                                        |
-| hide_empty_playlist_button | yes             | hides `playlist` button when a playlist does not exist                                                                                                        |
-| gray_empty_playlist_button | yes             | grays `playlist` button when no playlist exists                                                                                                               |
-| showjump                   | yes             | show `jump forward/backward 10 seconds` buttons                                                                                                               |
-| showskip                   | no              | show the `skip back/forward (chapter)` buttons                                                                                                                |
-| shownextprev               | yes             | show the `next/previous playlist track` buttons                                                                                                               |
-| showinfo                   | no              | show the `info (stats)` button                                                                                                                                |
-| showloop                   | yes             | show the `loop` button                                                                                                                                        |
-| showfullscreen_button      | yes             | show the `fullscreen toggle` button                                                                                                                           |
-| showontop                  | yes             | show `window on top (pin)` button                                                                                                                             |
-| showscreenshot             | no              | show `screenshot` button                                                                                                                                      |
-| screenshot_flag            | subtitles       | flag for the screenshot button. `subtitles` `video` `window` `each-frame` [[details](https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)] |
-| chapter_softrepeat         | yes             | holding chapter skip buttons repeats toggle                                                                                                                   |
-| jump_softrepeat            | yes             | holding jump seek buttons repeats toggle                                                                                                                      |
-| downloadbutton             | yes             | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                               |
-| download_path              | ~~desktop/mpv   | the download path for videos [[paths](https://mpv.io/manual/master/#paths)]                                                                                   |
+| Option             | Value            | Description                                                                      |
+| ------------------ | ---------------- | -------------------------------------------------------------------------------- |
+| showtitle          | yes              | show title in the OSC (above seekbar)                                            |
+| title              | `${media-title}` | title above seekbar format: `"${media-title}"` or `"${filename}"`                |
+| titlefontsize      | 30               | font size of the title text (above seekbar)                                      |
+| show_chapter_title | yes              | show chapter title alongside timestamp (below seekbar)                           |
+| chapter_fmt        | %s               | format for chapter display on seekbar hover (set to `"no"` to disable)           |
+| timetotal          | yes              | show total time instead of remaining time                                        |
+| timems             | no               | show timecodes with milliseconds                                                 |
+| unicodeminus       | no               | use the Unicode minus sign in remaining time                                     |
+| time_format        | dynamic          | `"dynamic"` or `"fixed"`. shows MM:SS when possible, fixed always shows HH:MM:SS |
+| timefontsize       | 18               | font size of the time display                                                    |
 
-### Scaling
+### Title bar settings
 
-| Option            | Value | Description                                                     |
-| ----------------- | ----- | --------------------------------------------------------------- |
-| vidscale          | auto  | whether to scale the controller with the video. `no` to disable |
-| scalewindowed     | 1.0   | scaling of the controller when windowed                         |
-| scalefullscreen   | 1.0   | scaling of the controller when fullscreen                       |
+| Option               | Value            | Description                                                               |
+| -------------------- | ---------------- | ------------------------------------------------------------------------- |
+| showwindowtitle      | yes              | show window title in borderless/fullscreen mode                           |
+| showwindowcontrols   | yes              | show window controls (close, minimize, maximize) in borderless/fullscreen |
+| titleBarStrip        | no               | show title bar as a single bar instead of a black fade                    |
+| windowcontrols_title | `${media-title}` | same as title but for windowcontrols                                      |
 
-### Time & Volume
+### Subtitle display settings
 
-| Option            | Value    | Description                                                                      |
-| ----------------- | -------- | -------------------------------------------------------------------------------- |
-| unicodeminus      | no       | whether to use the Unicode minus sign character in remaining time                |
-| timetotal         | yes      | display total time instead of remaining time?                                    |
-| timems            | no       | display timecodes with milliseconds                                              |
-| time_format       | dynamic  | dynamic or fixed. dynamic shows MM:SS when possible, fixed always shows HH:MM:SS |
-| timefontsize      | 18       | the font size of the time                                                        |
-| jumpamount        | 10       | change the jump amount (in seconds by default)                                   |
-| jumpiconnumber    | yes      | show different icon when jumpamount is `5`, `10`, or `30`                        |
-| jumpmode          | relative | seek mode for jump buttons                                                       |
-| volumecontrol     | yes      | whether to show mute button and volume slider                                    |
-| volumecontroltype | linear   | use `linear` or `log` (logarithmic) volume scale                                 |
+| Option         | Value | Description                                                            |
+| -------------- | ----- | ---------------------------------------------------------------------- |
+| raisesubs      | yes   | raise subtitles above the OSC when shown                               |
+| raisesubamount | 175   | amount by which subtitles are raised when the OSC is shown (in pixels) |
 
-### Seeking
+### Buttons display and functionality
 
-| Option                 | Value | Description                                                                          |
-| ---------------------- | ----- | ------------------------------------------------------------------------------------ |
-| seekbarkeyframes       | no    | use keyframes when dragging the seekbar                                              |
-| seekbarhandlesize      | 0.8   | size ratio of the slider handle, range 0 ~ 1                                         |
-| seekrange              | yes   | show seekrange overlay                                                               |
-| seekrangealpha         | 150   | transparency of seekranges                                                           |
-| livemarkers            | yes   | update seekbar chapter markers on duration change                                    |
-| osc_on_seek            | no    | show osc when seeking                                                                |
-| mouse_seek_pause       | yes   | should the video pause while seeking with mouse move? (on button hold)               |
-| automatickeyframemode  | yes   | set seekbarkeyframes based on video length to prevent laggy scrubbing on long videos |
-| automatickeyframelimit | 600   | videos of above this length (in seconds) will have seekbarkeyframes on               |
+| Option                     | Value         | Description                                                                                                                                                                                            |
+| -------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| showjump                   | yes           | show "jump forward/backward 10 seconds" buttons                                                                                                                                                        |
+| jumpamount                 | 10            | jump amount in seconds                                                                                                                                                                                 |
+| jumpiconnumber             | yes           | show different icon for `5`, `10`, or `30` second jumps                                                                                                                                                |
+| jumpmode                   | relative      | seek mode for jump buttons                                                                                                                                                                             |
+| jump_softrepeat            | yes           | enable continuous jumping when holding down seek buttons                                                                                                                                               |
+| showskip                   | no            | show the skip back and forward (chapter) buttons                                                                                                                                                       |
+| chapter_softrepeat         | yes           | enable continuous skipping when holding down chapter skip buttons                                                                                                                                      |
+| shownextprev               | yes           | show next/previous playlist track buttons                                                                                                                                                              |
+| volumecontrol              | yes           | show mute button and volume slider                                                                                                                                                                     |
+| volumecontroltype          | linear        | volume scale type: `"linear"` or `"logarithmic"`                                                                                                                                                       |
+| showplaylist               | no            | show playlist button: Left-click for simple playlist, Right-click for interactive playlist                                                                                                             |
+| hide_empty_playlist_button | yes           | hide playlist button when no playlist exists                                                                                                                                                           |
+| gray_empty_playlist_button | yes           | gray out the playlist button when no playlist exists                                                                                                                                                   |
+| downloadbutton             | yes           | show download button on web videos (requires yt-dlp and ffmpeg)                                                                                                                                        |
+| download_path              | ~~desktop/mpv | default download directory for videos. [Learn more about setting paths here](https://mpv.io/manual/master/#paths).                                                                                     |
+| showscreenshot             | no            | show screenshot button                                                                                                                                                                                 |
+| screenshot_flag            | subtitles     | Flag options for the screenshot button: `"subtitles"`, `"video"`, `"window"`, `"each-frame"`. [Find out more about these options](https://mpv.io/manual/master/#command-interface-screenshot-<flags>). |
+| showontop                  | yes           | show `window on top (pin)` button                                                                                                                                                                      |
+| showloop                   | yes           | show `loop` button                                                                                                                                                                                     |
+| loopinpause                | yes           | enable looping by right-clicking pause                                                                                                                                                                 |
+| showinfo                   | no            | show `info (stats)` button                                                                                                                                                                             |
+| showfullscreen_button      | yes           | show `fullscreen toggle` button                                                                                                                                                                        |
+| playpause_size             | 30            | icon size for the play/pause button                                                                                                                                                                    |
+| midbuttons_size            | 24            | icon size for the middle buttons                                                                                                                                                                       |
+| sidebuttons_size           | 24            | icon size for the side buttons                                                                                                                                                                         |
 
-### UI [elements]
+### Colors and style
 
-| Option                          | Value            | Description                                                                |
-| ------------------------------- | ---------------- | -------------------------------------------------------------------------- |
-| showtitle                       | yes              | show title in OSC (above seekbar)                                          |
-| showwindowtitle                 | yes              | show window title in borderless/fullscreen mode                            |
-| showwindowcontrols              | yes              | show window controls (close, min, max) in borderless/fullscreen            |
-| show_chapter_title              | yes              | show chapter title next to timestamp (below seekbar)                       |
-| titleBarStrip                   | no               | whether to make the title bar a singular bar instead of a black fade       |
-| title                           | `${media-title}` | title above seekbar                                                        |
-| windowcontrols_title            | `${media-title}` | title in windowcontrols                                                    |
-| font                            | mpv-osd-symbols  | mpv-osd-symbols = default osc font (or the one set in mpv.conf)            |
-| titlefontsize                   | 30               | the font size of the title text (above seekbar)                            |
-| chapter_fmt                     | %s               | chapter print format for seekbar-hover. `no` to disable                    |
-| tooltips_for_disabled_elements  | yes              | enables tooltips for disabled buttons and elements                         |
-| tooltip_hints                   | yes              | enables text hints for the information, loop, ontop and screenshot buttons |
-| playpause_size                  | 30               | icon size for the play-pause button                                        |
-| midbuttons_size                 | 24               | icon size for the middle buttons                                           |
-| sidebuttons_size                | 24               | icon size for the side buttons                                             |
-| persistentprogress              | no               | always show a small progress line at the bottom of the screen              |
-| persistentprogressheight        | 17               | the height of the persistentprogress bar                                   |
-| persistentbuffer                | no               | on web videos, show the buffer on the persistent progress line             |
+| Option                | Value   | Description                                                                            |
+| --------------------- | ------- | -------------------------------------------------------------------------------------- |
+| osc_color             | #000000 | accent color of the OSC and title bar                                                  |
+| window_title_color    | #FFFFFF | color of the title in borderless/fullscreen mode                                       |
+| window_controls_color | #FFFFFF | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode |
+| title_color           | #FFFFFF | color of the title (above seekbar)                                                     |
+| seekbarfg_color       | #BE4D25 | color of the seekbar progress and handle                                               |
+| seekbarbg_color       | #FFFFFF | color of the remaining seekbar                                                         |
+| seekbar_cache_color   | #BF9B24 | color of the cache ranges on the seekbar                                               |
+| vol_bar_match_seek    | no      | match volume bar color with seekbar color (ignores `side_buttons_color`)               |
+| time_color            | #FFFFFF | color of the timestamps (below seekbar)                                                |
+| chapter_title_color   | #FFFFFF | color of the chapter title next to timestamp (below seekbar)                           |
+| side_buttons_color    | #FFFFFF | color of the side buttons (audio, subtitles, playlist, etc.)                           |
+| middle_buttons_color  | #FFFFFF | color of the middle buttons (skip, jump, chapter, etc.)                                |
+| playpause_color       | #FFFFFF | color of the play/pause button                                                         |
+| held_element_color    | #999999 | color of the element when held down (pressed)                                          |
+| hovereffect_color     | #CB7050 | color of a hovered button when hovereffect includes `"color"`                          |
+| thumbnailborder_color | #111111 | color of the border for thumbnails (with thumbfast)                                    |
+| OSCfadealpha          | 150     | alpha of the OSC background box                                                        |
+| boxalpha              | 75      | alpha of the window title bar                                                          |
+| thumbnailborder       | 2       | width of the thumbnail border (for thumbfast)                                          |
 
-### UI [behavior]
+### Button hover effects
 
-| Option           | Value | Description                                                |
-| ---------------- | ----- | ---------------------------------------------------------- |
-| showonpause      | yes   | whether to show osc when paused                            |
-| keeponpause      | yes   | whether to disable the hide timeout on pause               |
-| bottomhover      | yes   | if the osc should only display when hovering at the bottom |
-| bottomhover_zone | 160   | height of show/hide zone for bottomhover                   |
-| raisesubs        | yes   | whether to raise subtitles above the osc when it's shown   |
-| raisesubamount   | 175   | how much subtitles rise when the osc is shown              |
-| thumbnailborder  | 2     | the width of the thumbnail border (thumbfast)              |
-| OSCfadealpha     | 150   | alpha of the background box for the OSC                    |
-| boxalpha         | 75    | alpha of the window title bar                              |
-| loopinpause      | yes   | activate looping by right clicking pause                   |
-| visibility       | auto  | only used at init to set visibility_mode(...)              |
+| Option                  | Value           | Description                                                                                      |
+| ----------------------- | --------------- | ------------------------------------------------------------------------------------------------ |
+| hovereffect             | size,glow,color | active button hover effects: `"glow"`, `"size"`, `"color"`; can use multiple separated by commas |
+| hover_button_size       | 115             | relative size of a hovered button if "size" effect is active                                     |
+| button_glow_amount      | 5               | glow intensity when `"glow"` hover effect is active                                              |
+| hovereffect_for_sliders | yes             | apply hover effects to slider handles                                                            |
 
-### UI [time-based]
+### Tooltips and hints
 
-| Option                        | Value  | Description                                            |
-| ----------------------------- | ------ | ------------------------------------------------------ |
-| hidetimeout                   | 2000   | duration in ms until OSC hides if no mouse movement    |
-| seek_resets_hidetimeout       | yes    | if seeking should reset the hidetimeout                |
-| fadeduration                  | 250    | duration of fade out in ms, `0` = no fade              |
-| minmousemove                  | 0      | amount of pixels the mouse has to move for OSC to show |
-| tick_delay                    | 0.0167 | minimum interval between OSC redraws in seconds        |
-| tick_delay_follow_display_fps | no     | use display fps as the minimum interval                |
+| Option                         | Value | Description                                                     |
+| ------------------------------ | ----- | --------------------------------------------------------------- |
+| tooltips_for_disabled_elements | yes   | enable tooltips for disabled buttons and elements               |
+| tooltip_hints                  | yes   | enable text hints for info, loop, ontop, and screenshot buttons |
+
+### Progress bar settings
+
+| Option                   | Value | Description                                                             |
+| ------------------------ | ----- | ----------------------------------------------------------------------- |
+| seekbarhandlesize        | 0.8   | size ratio of the seekbar handle (range: 0 ~ 1)                         |
+| seekrange                | yes   | show seek range overlay                                                 |
+| seekrangealpha           | 150   | transparency of the seek range                                          |
+| livemarkers              | yes   | update chapter markers on the seekbar when duration changes             |
+| seekbarkeyframes         | no    | use keyframes when dragging the seekbar                                 |
+| automatickeyframemode    | yes   | automatically set keyframes for the seekbar based on video length       |
+| automatickeyframelimit   | 600   | videos longer than this (in seconds) will have keyframes on the seekbar |
+| persistentprogress       | no    | always show a small progress line at the bottom of the screen           |
+| persistentprogressheight | 17    | height of the persistent progress bar                                   |
+| persistentbuffer         | no    | show buffer status on web videos in the persistent progress line        |
+
+### Miscellaneous settings
+
+| Option                        | Value  | Description                                       |
+| ----------------------------- | ------ | ------------------------------------------------- |
+| visibility                    | auto   | only used at init to set visibility_mode(...)     |
+| tick_delay                    | 0.0167 | minimum interval between OSC redraws (in seconds) |
+| tick_delay_follow_display_fps | no     | use display FPS as the minimum redraw interval    |
 
 ### Mouse Commands (User Options)
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -1,8 +1,14 @@
--- Samillion/ModernZ: https://github.com/Samillion/ModernZ
---- forked from zydezu/ModernX: https://github.com/zydezu/ModernX
----- forked from dexeonify: https://github.com/dexeonify/mpv-config/blob/main/scripts/modernx.lua
------ forked from cyl0: https://github.com/cyl0/ModernX
------- forked from maoiscat: https://github.com/maoiscat/mpv-osc-modern
+-- ModernZ (https://github.com/Samillion/ModernZ)
+--
+-- This script is a derivative of the original mpv-osc-modern by maoiscat 
+-- and subsequent forks:
+--   * cyl0/ModernX
+--   * dexeonify/ModernX
+--   * zydezu/ModernX
+--
+-- It is based on the official osc.lua from mpv, licensed under the 
+-- GNU Lesser General Public License v2.1 (LGPLv2.1). 
+-- Full license: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
 
 local assdraw = require "mp.assdraw"
 local msg = require "mp.msg"
@@ -13,134 +19,136 @@ local utils = require "mp.utils"
 -- default user option values
 -- do not touch, change them in modernz.conf
 local user_opts = {
-    -- General
-    language = "en",                       -- See https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md for other languages
-    idlescreen = true,                     -- show mpv logo on idle
-    windowcontrols = "auto",               -- whether to show OSC window controls, "auto", "yes" or "no"
-    showwindowed = true,                   -- show OSC when windowed?
-    showfullscreen = true,                 -- show OSC when fullscreen?
-    greenandgrumpy = false,                -- disable santa hat in December
+    -- Language and display  
+    language = "en",                       -- set language (for available options, see: https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md) 
+    font = "mpv-osd-symbols",              -- font for the OSC (default: mpv-osd-symbols or the one set in mpv.conf)
+    
+    idlescreen = true,                     -- show mpv logo when idle
+    windowcontrols = "auto",               -- show OSC window controls: "auto", "yes", or "no"
+    showwindowed = true,                   -- show OSC when windowed
+    showfullscreen = true,                 -- show OSC when fullscreen
+    showonpause = true,                    -- show OSC when paused
+    keeponpause = true,                    -- disable OSC hide timeout when paused 
+    greenandgrumpy = false,                -- disable Santa hat in December
 
-    -- Colors
-    osc_color = "#000000",                 -- accent of the OSC and the title bar
-    window_title_color = "#FFFFFF",        -- color of title in borderless/fullscreen mode
-    window_controls_color = "#FFFFFF",     -- color of window controls (close, min, max) in borderless/fullscreen mode
+    -- OSC behaviour and scaling
+    hidetimeout = 1500,                    -- time (in ms) before OSC hides if no mouse movement
+    seek_resets_hidetimeout = true,        -- if seeking should reset the hidetimeout
+    fadeduration = 250,                    -- fade-out duration (in ms), set to 0 for no fade
+    minmousemove = 0,                      -- minimum mouse movement (in pixels) required to show OSC
+    bottomhover = true,                    -- show OSC only when hovering at the bottom
+    bottomhover_zone = 160,                -- height of hover zone for bottomhover (in pixels)
+    osc_on_seek = false,                   -- show OSC when seeking
+    mouse_seek_pause = true,               -- pause video while seeking with mouse move (on button hold)
+
+    vidscale = "auto",                     -- scale osc with the video
+    scalewindowed = 1.0,                   -- osc scale factor when windowed
+    scalefullscreen = 1.0,                 -- osc scale factor when fullscreen
+
+    -- Time and title display
+    showtitle = true,                      -- show title in the OSC (above seekbar)
+    title = "${media-title}",              -- title above seekbar format: "${media-title}" or "${filename}"
+    titlefontsize = 30,                    -- font size of the title text (above seekbar)
+    
+    show_chapter_title = true,             -- show chapter title alongside timestamp (below seekbar)
+    chapter_fmt = "%s",                    -- format for chapter display on seekbar hover (set to "no" to disable)
+
+    timetotal = true,                      -- show total time instead of remaining time
+    timems = false,                        -- show timecodes with milliseconds
+    unicodeminus = false,                  -- use the Unicode minus sign in remaining time
+    time_format = "dynamic",               -- "dynamic" or "fixed". dynamic shows MM:SS when possible, fixed always shows HH:MM:SS
+    timefontsize = 18,                     -- font size of the time display
+
+    -- Title bar settings
+    showwindowtitle = true,                -- show window title in borderless/fullscreen mode
+    showwindowcontrols = true,             -- show window controls (close, minimize, maximize) in borderless/fullscreen
+    titleBarStrip = false,                 -- show title bar as a single bar instead of a black fade
+    windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
+
+    -- Subtitle display settings
+    raisesubs = true,                      -- raise subtitles above the OSC when shown
+    raisesubamount = 175,                  -- amount by which subtitles are raised when the OSC is shown (in pixels)
+
+    -- Buttons display and functionality
+    showjump = true,                       -- show "jump forward/backward 10 seconds" buttons
+    jumpamount = 10,                       -- jump amount in seconds
+    jumpiconnumber = true,                 -- show different icon for 5, 10, or 30 second jumps
+    jumpmode = "relative",                 -- seek mode for jump buttons
+    jump_softrepeat = true,                -- enable continuous jumping when holding down seek buttons
+    showskip = false,                      -- show the skip back and forward (chapter) buttons
+    chapter_softrepeat = true,             -- enable continuous skipping when holding down chapter skip buttons
+    shownextprev = true,                   -- show next/previous playlist track buttons
+
+    volumecontrol = true,                  -- show mute button and volume slider
+    volumecontroltype = "linear",          -- volume scale type: "linear" or "logarithmic"
+    showplaylist = false,                  -- show playlist button: Left-click for simple playlist, Right-click for interactive playlist
+    hide_empty_playlist_button = true,     -- hide playlist button when no playlist exists
+    gray_empty_playlist_button = true,     -- gray out the playlist button when no playlist exists
+
+    downloadbutton = true,                 -- show download button on web videos (requires yt-dlp and ffmpeg)
+    download_path = "~~desktop/mpv",       -- default download directory for videos (https://mpv.io/manual/master/#paths)
+    showscreenshot = false,                -- show screenshot button
+    screenshot_flag = "subtitles",         -- flag for screenshot button: "subtitles", "video", "window", "each-frame" (https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E)
+    showontop = true,                      -- show window on top button
+    showloop = true,                       -- show loop button
+    loopinpause = true,                    -- enable looping by right-clicking pause
+    showinfo = false,                      -- show info button
+    showfullscreen_button = true,          -- show fullscreen toggle button
+
+    playpause_size = 30,                   -- icon size for the play/pause button
+    midbuttons_size = 24,                  -- icon size for the middle buttons
+    sidebuttons_size = 24,                 -- icon size for the side buttons
+
+    -- Colors and style
+    osc_color = "#000000",                 -- accent color of the OSC and title bar
+    window_title_color = "#FFFFFF",        -- color of the title in borderless/fullscreen mode
+    window_controls_color = "#FFFFFF",     -- color of the window controls (close, minimize, maximize) in borderless/fullscreen mode
     title_color = "#FFFFFF",               -- color of the title (above seekbar)
     seekbarfg_color = "#BE4D25",           -- color of the seekbar progress and handle
     seekbarbg_color = "#FFFFFF",           -- color of the remaining seekbar
     seekbar_cache_color = "#BF9B24",       -- color of the cache ranges on the seekbar
-    vol_bar_match_seek = false,            -- match volume bar color with seekbar color? ignores side_buttons_color
-    time_color = "#FFFFFF",                -- color of timestamps (below seekbar)
-    chapter_title_color = "#FFFFFF",       -- color of chapter title next to timestamp (below seekbar)
-    side_buttons_color = "#FFFFFF",        -- color of side buttons (audio, sub, playlist, vol, loop, info..etc)
-    middle_buttons_color = "#FFFFFF",      -- color of middle buttons (skip, jump, chapter...etc)
-    playpause_color = "#FFFFFF",           -- color of play/pause button
-    held_element_color = "#999999",        -- color of an element while held down
-    thumbnailborder_color = "#111111",     -- color of border for thumbnail (with thumbfast)
-    hovereffect_color = "#CB7050",         -- color of a hovered button when hovereffect is: color
+    vol_bar_match_seek = false,            -- match volume bar color with seekbar color (ignores side_buttons_color)
+    time_color = "#FFFFFF",                -- color of the timestamps (below seekbar)
+    chapter_title_color = "#FFFFFF",       -- color of the chapter title next to timestamp (below seekbar)
+    side_buttons_color = "#FFFFFF",        -- color of the side buttons (audio, subtitles, playlist, etc.)
+    middle_buttons_color = "#FFFFFF",      -- color of the middle buttons (skip, jump, chapter, etc.)
+    playpause_color = "#FFFFFF",           -- color of the play/pause button
+    held_element_color = "#999999",        -- color of the element when held down (pressed)
+    hovereffect_color = "#CB7050",         -- color of a hovered button when hovereffect includes "color"
+    thumbnailborder_color = "#111111",     -- color of the border for thumbnails (with thumbfast)
 
-    -- Buttons
-    hovereffect = "size,glow,color",       -- list of active button hover effects seperated by comma: glow, size, color
-    hover_button_size = 115,               -- the relative size of a hovered button if the size effect is active
-    button_glow_amount = 5,                -- the amount of glow a hovered button receives if the glow effect is active
-    hovereffect_for_sliders = true,        -- apply button hovereffects to slide handles
+    OSCfadealpha = 150,                    -- alpha of the OSC background box
+    boxalpha = 75,                         -- alpha of the window title bar
+    thumbnailborder = 2,                   -- width of the thumbnail border (for thumbfast)
 
-    showjump = true,                       -- show "jump forward/backward 10 seconds" buttons 
-    showskip = false,                      -- show the chapter skip back and forward buttons
-    shownextprev = true,                   -- show the next/previous playlist track buttons
+    -- Button hover effects
+    hovereffect = "size,glow,color",       -- active button hover effects: "glow", "size", "color"; can use multiple separated by commas
+    hover_button_size = 115,               -- relative size of a hovered button if "size" effect is active
+    button_glow_amount = 5,                -- glow intensity when "glow" hover effect is active
+    hovereffect_for_sliders = true,        -- apply hover effects to slider handles
 
-    showplaylist = false,                  -- show playlist button? LClick: simple playlist, RClick: interactive playlist
-    hide_empty_playlist_button = true,     -- hide playlist button when no playlist exists
-    gray_empty_playlist_button = true,     -- grays out the playlist button when no playlist exists
-    showinfo = false,                      -- show the info button
-    showloop = true,                       -- show the loop button
-    showfullscreen_button = true,          -- show fullscreen toggle button
-    showontop = true,                      -- show window on top button
-    showscreenshot = false,                -- show screenshot button
-    screenshot_flag = "subtitles",         -- flag for the screenshot button. subtitles, video, window, each-frame
-                                           -- https://mpv.io/manual/master/#command-interface-screenshot-%3Cflags%3E
-    chapter_softrepeat = true,             -- holding chapter skip buttons repeats toggle
-    jump_softrepeat = true,                -- holding jump seek buttons repeats toggle
+    -- Tooltips and hints
+    tooltips_for_disabled_elements = true, -- enable tooltips for disabled buttons and elements
+    tooltip_hints = true,                  -- enable text hints for info, loop, ontop, and screenshot buttons
 
-    downloadbutton = true,                 -- show download button on web videos (requires yt-dlp and ffmpeg)
-    download_path = "~~desktop/mpv",       -- the download path for videos https://mpv.io/manual/master/#paths
-
-    -- Scaling
-    vidscale = "auto",                     -- whether to scale the controller with the video
-    scalewindowed = 1.0,                   -- scaling of the controller when windowed
-    scalefullscreen = 1.0,                 -- scaling of the controller when fullscreen
-
-    -- Time & Volume
-    unicodeminus = false,                  -- whether to use the Unicode minus sign character in remaining time
-    timetotal = true,                      -- display total time instead of remaining time?
-    timems = false,                        -- display timecodes with milliseconds?
-    time_format = "dynamic",               -- "dynamic" or "fixed". dynamic shows MM:SS when possible, fixed always shows HH:MM:SS
-    timefontsize = 18,                     -- the font size of the time
-    jumpamount = 10,                       -- change the jump amount (in seconds by default)
-    jumpiconnumber = true,                 -- show different icon when jumpamount is 5, 10, or 30
-    jumpmode = "relative",                 -- seek mode for jump buttons
-    volumecontrol = true,                  -- whether to show mute button and volume slider
-    volumecontroltype = "linear",          -- use "linear" or "log" (logarithmic) volume scale
-
-    -- Seeking
+    -- Progress bar settings 
+    seekbarhandlesize = 0.8,               -- size ratio of the seekbar handle (range: 0 ~ 1)
+    seekrange = true,                      -- show seek range overlay
+    seekrangealpha = 150,                  -- transparency of the seek range
+    livemarkers = true,                    -- update chapter markers on the seekbar when duration changes
     seekbarkeyframes = false,              -- use keyframes when dragging the seekbar
-    seekbarhandlesize = 0.8,               -- size ratio of the slider handle, range 0 ~ 1
-    seekrange = true,                      -- show seekrange overlay
-    seekrangealpha = 150,                  -- transparency of seekranges
-    livemarkers = true,                    -- update seekbar chapter markers on duration change
-
-    osc_on_seek = false,                   -- show osc when seeking? or input.conf: x script-message-to modernz osc-show
-    mouse_seek_pause = true,               -- should the video pause while seeking with mouse move? (on button hold)
-
-    automatickeyframemode = true,          -- set seekbarkeyframes based on video length to prevent laggy scrubbing on long videos 
-    automatickeyframelimit = 600,          -- videos of above this length (in seconds) will have seekbarkeyframes on
-
-    -- UI [elements]
-    showtitle = true,                      -- show title in OSC (above seekbar)
-    showwindowtitle = true,                -- show window title in borderless/fullscreen mode
-    showwindowcontrols = true,             -- show window controls (close, min, max) in borderless/fullscreen
-    show_chapter_title = true,             -- show chapter title next to timestamp (below seekbar)
-    titleBarStrip = false,                 -- whether to make the title bar a singular bar instead of a black fade
-    title = "${media-title}",              -- title above seekbar
-    windowcontrols_title = "${media-title}", -- title in windowcontrols
-    font = "mpv-osd-symbols",              -- mpv-osd-symbols = default osc font (or the one set in mpv.conf)
-    titlefontsize = 30,                    -- the font size of the title text (above seekbar)
-    chapter_fmt = "%s",                    -- chapter print format for seekbar-hover. "no" to disable
-
-    tooltips_for_disabled_elements = true, -- enables tooltips for disabled buttons and elements
-    tooltip_hints = true,                  -- enables text hints for the information, loop, ontop and screenshot buttons
-
-    playpause_size = 30,                   -- icon size for the play-pause button
-    midbuttons_size = 24,                  -- icon size for the middle buttons
-    sidebuttons_size = 24,                 -- icon size for the side buttons
+    
+    automatickeyframemode = true,          -- automatically set keyframes for the seekbar based on video length
+    automatickeyframelimit = 600,          -- videos longer than this (in seconds) will have keyframes on the seekbar 
 
     persistentprogress = false,            -- always show a small progress line at the bottom of the screen
-    persistentprogressheight = 17,         -- the height of the persistentprogress bar
-    persistentbuffer = false,              -- on web videos, show the buffer on the persistent progress line
+    persistentprogressheight = 17,         -- height of the persistent progress bar
+    persistentbuffer = false,              -- show buffer status on web videos in the persistent progress line
 
-    -- UI [behavior]
-    showonpause = true,                    -- whether to show osc when paused
-    keeponpause = true,                    -- whether to disable the hide timeout on pause
-    bottomhover = true,                    -- if the osc should only display when hovering at the bottom
-    bottomhover_zone = 160,                -- height of show/hide zone for bottomhover
-    raisesubs = true,                      -- whether to raise subtitles above the osc when it's shown
-    raisesubamount = 175,                  -- how much subtitles rise when the osc is shown
-    thumbnailborder = 2,                   -- the width of the thumbnail border (thumbfast)
-
-    OSCfadealpha = 150,                    -- alpha of the background box for the OSC
-    boxalpha = 75,                         -- alpha of the window title bar
-
-    loopinpause = true,                    -- activate looping by right clicking pause
+    -- Miscellaneous settings
     visibility = "auto",                   -- only used at init to set visibility_mode(...)
-
-    -- UI [time-based]
-    hidetimeout = 1500,                    -- duration in ms until OSC hides if no mouse movement
-    seek_resets_hidetimeout = true,        -- if seeking should reset the hidetimeout
-    fadeduration = 250,                    -- duration of fade out in ms, 0 = no fade
-    minmousemove = 0,                      -- amount of pixels the mouse has to move for OSC to show
-
-    tick_delay = 1 / 60,                   -- minimum interval between OSC redraws in seconds
-    tick_delay_follow_display_fps = false, -- use display fps as the minimum interval
+    tick_delay = 1 / 60,                   -- minimum interval between OSC redraws (in seconds)
+    tick_delay_follow_display_fps = false, -- use display FPS as the minimum redraw interval
 
     -- Mouse commands
     -- customize the button function based on mouse action
@@ -712,7 +720,7 @@ end
 -- convert slider_pos to logarithmic depending on volumecontrol user_opts
 local function set_volume(slider_pos)
     local volume = slider_pos
-    if user_opts.volumecontroltype == "log" then
+    if user_opts.volumecontroltype == "logarithmic" then
         volume = slider_pos^2 / 100
     end
     return math.floor(volume)
@@ -2064,7 +2072,7 @@ local function osc_init()
     ne.slider.seekRangesF = function() return nil end
     ne.slider.posF = function ()
         local volume = mp.get_property_number("volume")
-        if user_opts.volumecontrol == "log" then
+        if user_opts.volumecontrol == "logarithmic" then
             return math.sqrt(volume * 100)
         else
             return volume
@@ -3186,7 +3194,7 @@ local function validate_user_opts()
     end
 
     if user_opts.volumecontroltype ~= "linear" and
-       user_opts.volumecontroltype ~= "log" then
+       user_opts.volumecontroltype ~= "logarithmic" then
           msg.warn("volumecontrol cannot be '" .. user_opts.volumecontroltype .. "'. Ignoring.")
           user_opts.volumecontroltype = "linear"
     end


### PR DESCRIPTION
Initially I was going to reword some comments for clarity but ended up reordering the user options as well. The reordering reflects my personal preference on what I think makes sense, so I'm open to feedback on whether this approach is effective or if there are better ways to structure it.

### Changes
- Updated the header comment: Added licensing information and provided some info, aligning it with standard practices seen in other scripts.
- Made some comments more clear for better understanding, while trying to be consistent.
- Reordered and regrouped the user options.
- Changed the "log" value to "logarithmic" for consistency.

I considered splitting the buttons group into two distinct groups: one for showing and hiding buttons and another for the button functionality settings. It would look something like this:

``` lua
    -- Button visibility
    showjump = true,                       -- show "jump forward/backward 10 seconds" buttons
    showskip = false,                      -- show the skip back and forward (chapter) buttons
    shownextprev = true,                   -- show next/previous playlist track buttons
    volumecontrol = true,                  -- show mute button and volume slider
    showplaylist = false,                  -- show playlist button
    downloadbutton = true,                 -- show download button on web videos (requires yt-dlp and ffmpeg)
    showscreenshot = false,                -- show screenshot button
    showontop = true,                      -- show window on top button
    showloop = true,                       -- show loop button
    showinfo = false,                      -- show info button
    showfullscreen_button = true,          -- show fullscreen toggle button

    -- Button functionality
    jumpamount = 10,                       -- jump amount in seconds
    jumpiconnumber = true,                 -- show different icon for 5, 10, or 30 second jumps
    jumpmode = "relative",                 -- seek mode for jump buttons
    jump_softrepeat = true,                -- enable continuous jumping when holding down seek buttons
    chapter_softrepeat = true,             -- enable continuous skipping when holding down chapter skip buttons
    volumecontroltype = "linear",          -- volume scale type: "linear" or "logarithmic"
    hide_empty_playlist_button = true,     -- hide playlist button when no playlist exists
    gray_empty_playlist_button = true,     -- gray out the playlist button when no playlist exists
	download_path = "~~desktop/mpv",       -- default download directory for videos (https://mpv.io/manual/master/#paths)
    screenshot_flag = "subtitles",         -- flag for screenshot button
    loopinpause = true,                    -- enable looping by right-clicking pause
````