### PR TITLE
refactor: change event respond for chapter title to up press instead of down

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -59,7 +59,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 | Option               | Value            | Description                                                               |
 | -------------------- | ---------------- | ------------------------------------------------------------------------- |
-| showwindowtitle      | yes              | show window title in borderless/fullscreen mode                           |
+| showwindowtitle      | no               | show window title in borderless/fullscreen mode                           |
 | showwindowcontrols   | yes              | show window controls (close, minimize, maximize) in borderless/fullscreen |
 | titleBarStrip        | no               | show title bar as a single bar instead of a black fade                    |
 | windowcontrols_title | `${media-title}` | same as title but for windowcontrols                                      |
@@ -103,27 +103,27 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Colors and style
 
-| Option                | Value   | Description                                                                            |
-| --------------------- | ------- | -------------------------------------------------------------------------------------- |
-| osc_color             | #000000 | accent color of the OSC and title bar                                                  |
-| window_title_color    | #FFFFFF | color of the title in borderless/fullscreen mode                                       |
-| window_controls_color | #FFFFFF | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode |
-| title_color           | #FFFFFF | color of the title (above seekbar)                                                     |
-| seekbarfg_color       | #BE4D25 | color of the seekbar progress and handle                                               |
-| seekbarbg_color       | #FFFFFF | color of the remaining seekbar                                                         |
-| seekbar_cache_color   | #BF9B24 | color of the cache ranges on the seekbar                                               |
-| vol_bar_match_seek    | no      | match volume bar color with seekbar color (ignores `side_buttons_color`)               |
-| time_color            | #FFFFFF | color of the timestamps (below seekbar)                                                |
-| chapter_title_color   | #FFFFFF | color of the chapter title next to timestamp (below seekbar)                           |
-| side_buttons_color    | #FFFFFF | color of the side buttons (audio, subtitles, playlist, etc.)                           |
-| middle_buttons_color  | #FFFFFF | color of the middle buttons (skip, jump, chapter, etc.)                                |
-| playpause_color       | #FFFFFF | color of the play/pause button                                                         |
-| held_element_color    | #999999 | color of the element when held down (pressed)                                          |
-| hovereffect_color     | #CB7050 | color of a hovered button when hovereffect includes `"color"`                          |
-| thumbnailborder_color | #111111 | color of the border for thumbnails (with thumbfast)                                    |
-| OSCfadealpha          | 150     | alpha of the OSC background box                                                        |
-| boxalpha              | 75      | alpha of the window title bar                                                          |
-| thumbnailborder       | 2       | width of the thumbnail border (for thumbfast)                                          |
+| Option                | Value     | Description                                                                            |
+| --------------------- | --------- | -------------------------------------------------------------------------------------- |
+| osc_color             | `#000000` | accent color of the OSC and title bar                                                  |
+| window_title_color    | `#FFFFFF` | color of the title in borderless/fullscreen mode                                       |
+| window_controls_color | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode |
+| title_color           | `#FFFFFF` | color of the title (above seekbar)                                                     |
+| seekbarfg_color       | `#BE4D25` | color of the seekbar progress and handle                                               |
+| seekbarbg_color       | `#FFFFFF` | color of the remaining seekbar                                                         |
+| seekbar_cache_color   | `#BE254A` | color of the cache ranges on the seekbar                                               |
+| vol_bar_match_seek    | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)               |
+| time_color            | `#FFFFFF` | color of the timestamps (below seekbar)                                                |
+| chapter_title_color   | `#FFFFFF` | color of the chapter title next to timestamp (below seekbar)                           |
+| side_buttons_color    | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                           |
+| middle_buttons_color  | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                |
+| playpause_color       | `#FFFFFF` | color of the play/pause button                                                         |
+| held_element_color    | `#999999` | color of the element when held down (pressed)                                          |
+| hovereffect_color     | `#CB7050` | color of a hovered button when hovereffect includes `"color"`                          |
+| thumbnailborder_color | `#111111` | color of the border for thumbnails (with thumbfast)                                    |
+| OSCfadealpha          | 150       | alpha of the OSC background box                                                        |
+| boxalpha              | 75        | alpha of the window title bar                                                          |
+| thumbnailborder       | 2         | width of the thumbnail border (for thumbfast)                                          |
 
 ### Button hover effects
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -26,7 +26,7 @@ seekbarfg_color=#BE4D25
 # color of the remaining seekbar
 seekbarbg_color=#FFFFFF
 # color of the cache ranges on the seekbar
-seekbar_cache_color=#BF9B24
+seekbar_cache_color=#BE254A
 # match volume bar color with seekbar color? ignores side_buttons_color
 vol_bar_match_seek=no
 # color of timestamps (below seekbar)
@@ -144,7 +144,7 @@ automatickeyframelimit=600
 # show title in OSC (above seekbar)
 showtitle=yes
 # show window title in borderless/fullscreen mode
-showwindowtitle=yes
+showwindowtitle=no
 # show window controls (close, min, max) in borderless/fullscreen
 showwindowcontrols=yes
 # whether to make the title bar a singular bar instead of a black fade

--- a/modernz.lua
+++ b/modernz.lua
@@ -60,7 +60,7 @@ local user_opts = {
     timefontsize = 18,                     -- font size of the time display
 
     -- Title bar settings
-    showwindowtitle = true,                -- show window title in borderless/fullscreen mode
+    showwindowtitle = false,               -- show window title in borderless/fullscreen mode
     showwindowcontrols = true,             -- show window controls (close, minimize, maximize) in borderless/fullscreen
     titleBarStrip = false,                 -- show title bar as a single bar instead of a black fade
     windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
@@ -106,7 +106,7 @@ local user_opts = {
     title_color = "#FFFFFF",               -- color of the title (above seekbar)
     seekbarfg_color = "#BE4D25",           -- color of the seekbar progress and handle
     seekbarbg_color = "#FFFFFF",           -- color of the remaining seekbar
-    seekbar_cache_color = "#BF9B24",       -- color of the cache ranges on the seekbar
+    seekbar_cache_color = "#BE254A",       -- color of the cache ranges on the seekbar
     vol_bar_match_seek = false,            -- match volume bar color with seekbar color (ignores side_buttons_color)
     time_color = "#FFFFFF",                -- color of the timestamps (below seekbar)
     chapter_title_color = "#FFFFFF",       -- color of the chapter title next to timestamp (below seekbar)
@@ -2444,8 +2444,8 @@ local function osc_init()
         end
         return "" -- fallback
     end
-    ne.eventresponder["mbtn_left_down"] = command_callback(user_opts.chapter_title_mbtn_left_command)
-    ne.eventresponder["mbtn_right_down"] = command_callback(user_opts.chapter_title_mbtn_right_command)
+    ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.chapter_title_mbtn_left_command)
+    ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.chapter_title_mbtn_right_command)
 
     -- Total/remaining time display
     ne = new_element("tc_right", "button")


### PR DESCRIPTION
This is to prevent accidental clicks on chapter title select menu. (below seekbar)