### PR TITLE
fix: correctly fill cache color in slider

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -969,8 +969,8 @@ local function render_elements(master_ass)
                         local pend = get_slider_ele_pos_for(element, range["end"])
 
                         local cache_starts_in_handle = pstart >= xp-rh and pstart <= xp + rh
-                        local cache_ends_in_handle = pend >= xp-rh and pend <= xp + rh
-                        local cache_passes_handle = pstart < xp-rh and pend > xp + rh
+                        local cache_ends_in_handle = pend >= xp-rh and pend <= xp
+                        local cache_passes_handle = pstart < xp-rh and pend > xp
                         if cache_starts_in_handle or cache_ends_in_handle then
                             if cache_starts_in_handle and cache_ends_in_handle then
                                 pstart = 0
@@ -988,7 +988,7 @@ local function render_elements(master_ass)
                             pstart = pstart - rh
                         end
 
-                        elem_ass:rect_cw(pstart, slider_lo.gap, pend + rh, elem_geo.h - slider_lo.gap)
+                        elem_ass:rect_cw(pstart, slider_lo.gap, pend + (cache_ends_in_handle and 0 or rh), elem_geo.h - slider_lo.gap)
                     end
                 end
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -984,7 +984,7 @@ local function render_elements(master_ass)
                             pstart = xp + rh
                         end
 
-                        elem_ass:rect_cw(pstart, slider_lo.gap, pend, elem_geo.h - slider_lo.gap)
+                        elem_ass:rect_cw(pstart - rh, slider_lo.gap, pend + rh, elem_geo.h - slider_lo.gap)
                     end
                 end
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -982,11 +982,13 @@ local function render_elements(master_ass)
                             end
                         elseif cache_passes_handle then
                             -- split range rendering to avoid rendering above handle
-                            elem_ass:rect_cw(pstart, slider_lo.gap, xp - rh, elem_geo.h - slider_lo.gap)
+                            elem_ass:rect_cw(pstart - rh, slider_lo.gap, xp - rh, elem_geo.h - slider_lo.gap)
                             pstart = xp + rh
+                        else
+                            pstart = pstart - rh
                         end
 
-                        elem_ass:rect_cw(pstart - rh, slider_lo.gap, pend + rh, elem_geo.h - slider_lo.gap)
+                        elem_ass:rect_cw(pstart, slider_lo.gap, pend + rh, elem_geo.h - slider_lo.gap)
                     end
                 end
 


### PR DESCRIPTION
Pinging @Commander07 and @ctlaltdefeat

There is a gap at the end of the seekbar, because the cache color doesn't address the handle size

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/a2172bbe-4ecb-477a-bd34-840dff0929e8) | ![After](https://github.com/user-attachments/assets/6713b368-3f76-4f01-b8c2-2670cf97d1b3) |

**Test with:** 
- [dev_slider_gap_fill/modernz.lua](https://github.com/Samillion/ModernZ/blob/dev_slider_gap_fill/modernz.lua)

**Changes:**
```diff
- elem_ass:rect_cw(pstart, slider_lo.gap, pend, elem_geo.h - slider_lo.gap)
+ elem_ass:rect_cw(pstart - rh, slider_lo.gap, pend + rh, elem_geo.h - slider_lo.gap)
```