### PR TITLE
feat: add dedicated layout for image mode

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1831,10 +1831,8 @@ layouts["modern-image"] = function ()
 
     local shownextprev = user_opts.shownextprev
     local showfullscreen = user_opts.showfullscreen_button
-    local showloop = user_opts.showloop
     local showinfo = user_opts.showinfo
     local showontop = user_opts.showontop
-    local showscreenshot = user_opts.showscreenshot
     local showplaylist = user_opts.showplaylist and (not user_opts.hide_empty_playlist_button or mp.get_property_number("playlist-count", 0) > 1)
 
     local offset = 0
@@ -1882,30 +1880,16 @@ layouts["modern-image"] = function ()
         lo.visible = (osc_param.playresx >= 300 - outeroffset)
     end
 
-    if showloop then
-        lo = add_layout("tog_loop")
-        lo.geometry = {x = osc_geo.w - 127 + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
-        lo.style = osc_styles.control_3
-        lo.visible = (osc_param.playresx >= 400 - outeroffset)
-    end
-
     if showontop then
         lo = add_layout("tog_ontop")
-        lo.geometry = {x = osc_geo.w - 172 + (showloop and 0 or 45) + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
+        lo.geometry = {x = osc_geo.w - 127 + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
         lo.style = osc_styles.control_3
         lo.visible = (osc_param.playresx >= 500 - outeroffset)
-    end
-
-    if showscreenshot then
-        lo = add_layout("screenshot")
-        lo.geometry = {x = osc_geo.w - 217 + (showontop and 0 or 45) + (showloop and 0 or 45) + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
-        lo.style = osc_styles.control_3
-        lo.visible = (osc_param.playresx >= 600 - outeroffset)
     end
     
     if user_opts.downloadbutton then
         lo = add_layout("download")
-        lo.geometry = {x = osc_geo.w - 262 + (showscreenshot and 0 or 45) + (showontop and 0 or 45) + (showloop and 0 or 45) + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
+        lo.geometry = {x = osc_geo.w - 172 + (showontop and 0 or 45) + (showinfo and 0 or 45) + (showfullscreen and 0 or 45), y = refY - 40, an = 5, w = 24, h = 24}
         lo.style = osc_styles.control_3
         lo.visible = (osc_param.playresx >= 400 - outeroffset)
     end

--- a/modernz.lua
+++ b/modernz.lua
@@ -1831,10 +1831,10 @@ layouts["modern-image"] = function ()
 
     local shownextprev = user_opts.shownextprev
     local showfullscreen = user_opts.showfullscreen_button
-    local showloop = user_opts.showloop and should_show
+    local showloop = user_opts.showloop
     local showinfo = user_opts.showinfo
     local showontop = user_opts.showontop
-    local showscreenshot = user_opts.showscreenshot and should_show
+    local showscreenshot = user_opts.showscreenshot
     local showplaylist = user_opts.showplaylist and (not user_opts.hide_empty_playlist_button or mp.get_property_number("playlist-count", 0) > 1)
 
     local offset = 0
@@ -1864,7 +1864,7 @@ layouts["modern-image"] = function ()
         lo = add_layout("tog_playlist")
         lo.geometry = {x = 25, y = refY - 40, an = 5, w = 24, h = 24}
         lo.style = osc_styles.control_3
-        lo.visible = (osc_param.playresx >= 600 - outeroffset)
+        lo.visible = (osc_param.playresx >= 250 - outeroffset)
     end
 
     -- Fullscreen/Info/Loop/Pin/Screenshot

--- a/modernz.lua
+++ b/modernz.lua
@@ -2591,7 +2591,6 @@ local function osc_init()
     end
 
     -- load layout
-    is_image() -- init check if it's an image file
     if state.is_image then
         layouts["modern-image"]()
     else
@@ -3082,6 +3081,7 @@ local function set_tick_delay(_, display_fps)
 end
 
 mp.register_event("file-loaded", function() 
+    is_image() -- check if file is an image
     state.fileSizeNormalised = "Approximating size..."
     check_path_url()
 end)


### PR DESCRIPTION
Pinging @Commander07 

Pinging @Xurdejl and @Keith94 as well.

Terribly sorry for the bother. Only if you can, could you help me test this please?

This is a restructure of https://github.com/Samillion/ModernZ/pull/158

**Now there are two layouts:**
- `modern`
- `modern-image`

**Handled with:**
```lua
    -- load layout
    is_image() -- init check if it's an image file
    if state.is_image then
        layouts["modern-image"]()
    else
        layouts["modern"]()
    end
```

**The `is_image()` function determines if the file is an image or not:**
```lua
local function is_image()
    local current_track = mp.get_property_native("current-tracks/video")
    if current_track and current_track.image and not current_track.albumart 
       and mp.get_property_number("estimated-frame-count", 0) < 2 and audio_track_count == 0 then
        state.is_image = true
    else
        state.is_image = false
    end
end
```

**Test script:** [/dev_imagemode_layout/modernz.lua](https://github.com/Samillion/ModernZ/blob/dev_imagemode_layout/modernz.lua)