### PR TITLE
feat: add option to control blur amount for background alpha

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -103,27 +103,28 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Colors and style
 
-| Option                     | Value     | Description                                                                            |
-| -------------------------- | --------- | -------------------------------------------------------------------------------------- |
-| osc_color                  | `#000000` | accent color of the OSC and title bar                                                  |
-| window_title_color         | `#FFFFFF` | color of the title in borderless/fullscreen mode                                       |
-| window_controls_color      | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode |
-| title_color                | `#FFFFFF` | color of the title (above seekbar)                                                     |
-| seekbarfg_color            | `#BE4D25` | color of the seekbar progress and handle                                               |
-| seekbarbg_color            | `#FFFFFF` | color of the remaining seekbar                                                         |
-| seekbar_cache_color        | `#BE254A` | color of the cache ranges on the seekbar                                               |
-| volumebar_match_seek_color | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)               |
-| time_color                 | `#FFFFFF` | color of the timestamps (below seekbar)                                                |
-| chapter_title_color        | `#FFFFFF` | color of the chapter title next to timestamp (below seekbar)                           |
-| side_buttons_color         | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                           |
-| middle_buttons_color       | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                |
-| playpause_color            | `#FFFFFF` | color of the play/pause button                                                         |
-| held_element_color         | `#999999` | color of the element when held down (pressed)                                          |
-| hover_effect_color         | `#CB7050` | color of a hovered button when `hover_effect` includes `"color"`                       |
-| thumbnail_border_color     | `#111111` | color of the border for thumbnails (with thumbfast)                                    |
-| fade_alpha                 | 150       | alpha of the OSC background box                                                        |
-| window_fade_alpha          | 75        | alpha of the window title bar                                                          |
-| thumbnail_border           | 2         | width of the thumbnail border (for thumbfast)                                          |
+| Option                     | Value     | Description                                                                                           |
+| -------------------------- | --------- | ----------------------------------------------------------------------------------------------------- |
+| osc_color                  | `#000000` | accent color of the OSC and title bar                                                                 |
+| window_title_color         | `#FFFFFF` | color of the title in borderless/fullscreen mode                                                      |
+| window_controls_color      | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode                |
+| title_color                | `#FFFFFF` | color of the title (above seekbar)                                                                    |
+| seekbarfg_color            | `#BE4D25` | color of the seekbar progress and handle                                                              |
+| seekbarbg_color            | `#FFFFFF` | color of the remaining seekbar                                                                        |
+| seekbar_cache_color        | `#BE254A` | color of the cache ranges on the seekbar                                                              |
+| volumebar_match_seek_color | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                              |
+| time_color                 | `#FFFFFF` | color of the timestamps (below seekbar)                                                               |
+| chapter_title_color        | `#FFFFFF` | color of the chapter title next to timestamp (below seekbar)                                          |
+| side_buttons_color         | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                                          |
+| middle_buttons_color       | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                               |
+| playpause_color            | `#FFFFFF` | color of the play/pause button                                                                        |
+| held_element_color         | `#999999` | color of the element when held down (pressed)                                                         |
+| hover_effect_color         | `#CB7050` | color of a hovered button when `hover_effect` includes `"color"`                                      |
+| thumbnail_border_color     | `#111111` | color of the border for thumbnails (with thumbfast)                                                   |
+| fade_alpha                 | 150       | alpha of the OSC background box                                                                       |
+| fade_blur_amount           | 100       | blur level for the OSC background fade. **caution**: high values can take a lot of CPU time to render |
+| window_fade_alpha          | 75        | alpha of the window title bar                                                                         |
+| thumbnail_border           | 2         | width of the thumbnail border (for thumbfast)                                                         |
 
 ### Button hover effects
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -187,6 +187,8 @@ raise_subtitle_amount=175
 thumbnail_border=2
 # alpha of the background box for the OSC
 fade_alpha=150
+# blur level for the OSC background fade. caution: high values can take a lot of CPU time to render
+fade_blur_amount=100
 # alpha of the window title bar
 window_fade_alpha=75
 # activate looping by right clicking pause

--- a/modernz.lua
+++ b/modernz.lua
@@ -121,6 +121,7 @@ local user_opts = {
     thumbnail_border_color = "#111111",    -- color of the border for thumbnails (with thumbfast)
 
     fade_alpha = 150,                      -- alpha of the OSC background box
+    fade_blur_amount = 100,                -- blur level for the OSC background fade. caution: high values can take a lot of CPU time to render.
     window_fade_alpha = 75,                -- alpha of the window title bar
     thumbnail_border = 2,                  -- width of the thumbnail border (for thumbfast)
 
@@ -365,7 +366,7 @@ local function set_osc_styles()
     local sidebuttons_size = user_opts.sidebuttons_size or 24
     osc_styles = {
         background_bar = "{\\1c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
-        box_bg = "{\\blur100\\bord" .. user_opts.fade_alpha .. "\\1c&H000000&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
+        box_bg = "{\\blur" .. user_opts.fade_blur_amount .. "\\bord" .. user_opts.fade_alpha .. "\\1c&H000000&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
         chapter_title = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.chapter_title_color) .. "&\\3c&H000000&\\fs" .. user_opts.time_font_size .. "\\fn" .. user_opts.font .. "}",
         control_1 = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.playpause_color) .. "&\\3c&HFFFFFF&\\fs" .. playpause_size .. "\\fn" .. iconfont .. "}",
         control_2 = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.middle_buttons_color) .. "&\\3c&HFFFFFF&\\fs" .. midbuttons_size .. "\\fn" .. iconfont .. "}",


### PR DESCRIPTION
The blur level has been set to 100 ever since the `Modern` origin was made, which is fine for most users. However, this is highly dependent on CPU, and some computers might have a slow render time because of it.

Now the user can easily adjust it to their suitable level in `modernz.conf`.

**Example:** (slow render)
![image](https://github.com/user-attachments/assets/94acd0b6-0b5c-469d-ac47-8f8734f93382)

Thanks to @guidocella for the screenshot and @kasper93 for noting that blur amount (strength) is the cause.

**Details:** (search for `\blur`)
https://aegisub.org/docs/latest/ass_tags/
>Quote:  Be careful, setting strength too high can take a lot of CPU time to render.