### PR TITLE
fix(gitattributes): enforce LF line endings and fix Linguist language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
-*           text=auto
-*           text eol=lf
-*.conf      linguist-language=editorconfig
+*           text=auto 
+*.conf      linguist-language=EditorConfig


### PR DESCRIPTION
The previous .gitattributes was causing unexpected behaviour, such as showing unsaved changes after a fresh clone.

According to the [documentation](http://git-scm.com/docs/gitattributes#_end_of_line_conversion), `* text=auto` ensures that all text files in the repository will have consistent LF line endings. Therefore, the `* text eol=lf` line is unnecessary and can be removed.

GitHub Linguist is case-sensitive when identifying languages. The correct alias for EditorConfig is "editor-config". Using lowercase will not be recognized.
For reference: [linguist/languages.yml](https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/languages.yml#L1842-L1850)