### PR TITLE
fix: respect OSC visibility over paused visibility

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3378,7 +3378,7 @@ end
 
 mp.observe_property("pause", "bool", function(name, enabled)
     pause_state(name, enabled)
-    if user_opts.showonpause then
+    if user_opts.showonpause and user_opts.visibility ~= "never" then
         if enabled then
             -- save mode if a temporary change is needed
             if not state.temp_visibility_mode and user_opts.visibility ~= "always" then


### PR DESCRIPTION
Adds a conditional check to `showonpaused` so it won't trigger when the user has the visibility set to `never`. Closes #246.