### PR TITLE
fix: don't place the overlay above other ones

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3103,7 +3103,7 @@ local function render()
 
     -- submit
     set_osd(osc_param.playresy * osc_param.display_aspect,
-            osc_param.playresy, ass.text, 1000)
+            osc_param.playresy, ass.text, -1)
 end
 
 -- called by mpv on every frame


### PR DESCRIPTION
Stop setting the `z` level of the OSC overlay. This prevents the console/select menu from being drawn below the layout when clicking buttons