### PR TITLE
feat: add more chapter marker styles with nibbles_style

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -156,21 +156,22 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Progress bar settings
 
-| Option                   | Value | Description                                                                |
-| ------------------------ | ----- | -------------------------------------------------------------------------- |
-| seekbarhandlesize        | 0.8   | size ratio of the seekbar handle (range: 0 ~ 1)                            |
-| handle_always_visible    | no    | control handle visibility: `yes` always visible, `no` show on slider hover |
-| seekrange                | yes   | show seek range overlay                                                    |
-| seekrangealpha           | 150   | transparency of the seek range                                             |
-| livemarkers              | yes   | update chapter markers on the seekbar when duration changes                |
-| seekbarkeyframes         | no    | use keyframes when dragging the seekbar                                    |
-| nibbles_top              | yes   | top chapter nibbles above seekbar                                          |
-| nibbles_bottom           | yes   | bottom chapter nibbles below seekbar                                       |
-| automatickeyframemode    | yes   | automatically set keyframes for the seekbar based on video length          |
-| automatickeyframelimit   | 600   | videos longer than this (in seconds) will have keyframes on the seekbar    |
-| persistentprogress       | no    | always show a small progress line at the bottom of the screen              |
-| persistentprogressheight | 17    | height of the persistent progress bar                                      |
-| persistentbuffer         | no    | show buffer status on web videos in the persistent progress line           |
+| Option                   | Value    | Description                                                                |
+| ------------------------ | -------- | -------------------------------------------------------------------------- |
+| seekbarhandlesize        | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                            |
+| handle_always_visible    | no       | control handle visibility: `yes` always visible, `no` show on slider hover |
+| seekrange                | yes      | show seek range overlay                                                    |
+| seekrangealpha           | 150      | transparency of the seek range                                             |
+| livemarkers              | yes      | update chapter markers on the seekbar when duration changes                |
+| seekbarkeyframes         | no       | use keyframes when dragging the seekbar                                    |
+| nibbles_top              | yes      | top chapter nibbles above seekbar                                          |
+| nibbles_bottom           | yes      | bottom chapter nibbles below seekbar                                       |
+| nibbles_style            | triangle | chapter nibble style. `triangle` or `bar`                                  |
+| automatickeyframemode    | yes      | automatically set keyframes for the seekbar based on video length          |
+| automatickeyframelimit   | 600      | videos longer than this (in seconds) will have keyframes on the seekbar    |
+| persistentprogress       | no       | always show a small progress line at the bottom of the screen              |
+| persistentprogressheight | 17       | height of the persistent progress bar                                      |
+| persistentbuffer         | no       | show buffer status on web videos in the persistent progress line           |
 
 ### Miscellaneous settings
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -166,7 +166,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | seekbarkeyframes         | no       | use keyframes when dragging the seekbar                                    |
 | nibbles_top              | yes      | top chapter nibbles above seekbar                                          |
 | nibbles_bottom           | yes      | bottom chapter nibbles below seekbar                                       |
-| nibbles_style            | triangle | chapter nibble style. `triangle` or `bar`                                  |
+| nibbles_style            | triangle | chapter nibble style. `triangle`, `bar` or `single-bar`                    |
 | automatickeyframemode    | yes      | automatically set keyframes for the seekbar based on video length          |
 | automatickeyframelimit   | 600      | videos longer than this (in seconds) will have keyframes on the seekbar    |
 | persistentprogress       | no       | always show a small progress line at the bottom of the screen              |

--- a/modernz.conf
+++ b/modernz.conf
@@ -240,7 +240,7 @@ seekbarkeyframes=no
 nibbles_top=yes
 # bottom chapter nibbles below seekbar
 nibbles_bottom=yes
-# chapter nibble style. "triangle" or "bar"
+# chapter nibble style. "triangle", "bar" or "single-bar"
 nibbles_style=triangle
 
 # automatically set keyframes for the seekbar based on video length

--- a/modernz.conf
+++ b/modernz.conf
@@ -240,6 +240,8 @@ seekbarkeyframes=no
 nibbles_top=yes
 # bottom chapter nibbles below seekbar
 nibbles_bottom=yes
+# chapter nibble style. "triangle" or "bar"
+nibbles_style=triangle
 
 # automatically set keyframes for the seekbar based on video length
 automatickeyframemode=yes

--- a/modernz.lua
+++ b/modernz.lua
@@ -158,7 +158,7 @@ local user_opts = {
 
     nibbles_top = true,                    -- top chapter nibbles above seekbar
     nibbles_bottom = true,                 -- bottom chapter nibbles below seekbar
-    nibbles_style = "triangle",            -- chapter nibble style. "triangle" or "bar"
+    nibbles_style = "triangle",            -- chapter nibble style. "triangle", "bar", or "single-bar"
 
     automatickeyframemode = true,          -- automatically set keyframes for the seekbar based on video length
     automatickeyframelimit = 600,          -- videos longer than this (in seconds) will have keyframes on the seekbar 
@@ -860,15 +860,18 @@ local function prepare_elements()
                     if marker >= element.slider.min.value and 
                     marker <= element.slider.max.value then
                         local s = get_slider_ele_pos_for(element, marker)
-                        if slider_lo.gap > 5 then -- draw triangles
+                        if slider_lo.gap > 5 then -- draw triangles / bars
+                            local bar_h = 3 -- for "bar" and "single-bar" only
                             --top
                             if slider_lo.nibbles_top then
                                 if slider_lo.nibbles_style == "triangle" then
                                     static_ass:move_to(s - 3, slider_lo.gap - 5)
                                     static_ass:line_to(s + 3, slider_lo.gap - 5)
                                     static_ass:line_to(s, slider_lo.gap - 1)
+                                elseif slider_lo.nibbles_style == "bar" then
+                                    static_ass:rect_cw(s - 1, slider_lo.gap - bar_h, s + 1, slider_lo.gap);
                                 else
-                                    static_ass:rect_cw(s - 1, 4, s + 1, slider_lo.gap + 4);
+                                    static_ass:rect_cw(s - 1, slider_lo.gap - bar_h, s + 1, elem_geo.h - slider_lo.gap);
                                 end
                             end
                             --bottom
@@ -877,8 +880,10 @@ local function prepare_elements()
                                     static_ass:move_to(s - 3, elem_geo.h - slider_lo.gap + 5)
                                     static_ass:line_to(s, elem_geo.h - slider_lo.gap + 1)
                                     static_ass:line_to(s + 3, elem_geo.h - slider_lo.gap + 5)
+                                elseif slider_lo.nibbles_style == "bar" then
+                                    static_ass:rect_cw(s - 1, elem_geo.h - slider_lo.gap, s + 1, elem_geo.h - slider_lo.gap + bar_h);
                                 else
-                                    static_ass:rect_cw(s - 1, elem_geo.h - slider_lo.gap - 4, s + 1, elem_geo.h - 4);
+                                    static_ass:rect_cw(s - 1, slider_lo.gap, s + 1, elem_geo.h - slider_lo.gap + bar_h);
                                 end
                             end
                         else -- draw 2x1px nibbles

--- a/modernz.lua
+++ b/modernz.lua
@@ -158,6 +158,7 @@ local user_opts = {
 
     nibbles_top = true,                    -- top chapter nibbles above seekbar
     nibbles_bottom = true,                 -- bottom chapter nibbles below seekbar
+    nibbles_style = "triangle",            -- chapter nibble style. "triangle" or "bar"
 
     automatickeyframemode = true,          -- automatically set keyframes for the seekbar based on video length
     automatickeyframelimit = 600,          -- videos longer than this (in seconds) will have keyframes on the seekbar 
@@ -862,15 +863,23 @@ local function prepare_elements()
                         if slider_lo.gap > 5 then -- draw triangles
                             --top
                             if slider_lo.nibbles_top then
-                                static_ass:move_to(s - 3, slider_lo.gap - 5)
-                                static_ass:line_to(s + 3, slider_lo.gap - 5)
-                                static_ass:line_to(s, slider_lo.gap - 1)
+                                if slider_lo.nibbles_style == "triangle" then
+                                    static_ass:move_to(s - 3, slider_lo.gap - 5)
+                                    static_ass:line_to(s + 3, slider_lo.gap - 5)
+                                    static_ass:line_to(s, slider_lo.gap - 1)
+                                else
+                                    static_ass:rect_cw(s - 1, 4, s + 1, slider_lo.gap + 4);
+                                end
                             end
                             --bottom
                             if slider_lo.nibbles_bottom then
-                                static_ass:move_to(s - 3, elem_geo.h - slider_lo.gap + 5)
-                                static_ass:line_to(s, elem_geo.h - slider_lo.gap + 1)
-                                static_ass:line_to(s + 3, elem_geo.h - slider_lo.gap + 5)
+                                if slider_lo.nibbles_style == "triangle" then
+                                    static_ass:move_to(s - 3, elem_geo.h - slider_lo.gap + 5)
+                                    static_ass:line_to(s, elem_geo.h - slider_lo.gap + 1)
+                                    static_ass:line_to(s + 3, elem_geo.h - slider_lo.gap + 5)
+                                else
+                                    static_ass:rect_cw(s - 1, elem_geo.h - slider_lo.gap - 4, s + 1, elem_geo.h - 4);
+                                end
                             end
                         else -- draw 2x1px nibbles
                             --top
@@ -1483,6 +1492,7 @@ local function add_layout(name)
                 gap = 1,
                 nibbles_top = user_opts.nibbles_top,
                 nibbles_bottom = user_opts.nibbles_bottom,
+                nibbles_style = user_opts.nibbles_style,
                 adjust_tooltip = true,
                 tooltip_style = "",
                 tooltip_an = 2,
@@ -1672,16 +1682,18 @@ layouts["modern"] = function ()
     -- Seekbar
     new_element("seekbarbg", "box")
     lo = add_layout("seekbarbg")
-    lo.geometry = {x = refX, y = refY - 72, an = 5, w = osc_geo.w - 50, h = 4}
+    local seekbar_bg_h = 4
+    lo.geometry = {x = refX, y = refY - 72, an = 5, w = osc_geo.w - 50, h = seekbar_bg_h}
     lo.layer = 13
     lo.style = osc_styles.seekbar_bg
     lo.alpha[1] = 128
     lo.alpha[3] = 128
 
     lo = add_layout("seekbar")
-    lo.geometry = {x = refX, y = refY - 72, an = 5, w = osc_geo.w - 50, h = 18}
+    local seekbar_h = 18
+    lo.geometry = {x = refX, y = refY - 72, an = 5, w = osc_geo.w - 50, h = seekbar_h}
     lo.style = osc_styles.seekbar_fg
-    lo.slider.gap = 7
+    lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
     lo.slider.tooltip_style = osc_styles.tooltip
     lo.slider.tooltip_an = 2
 
@@ -1689,7 +1701,7 @@ layouts["modern"] = function ()
         lo = add_layout("persistentseekbar")
         lo.geometry = {x = refX, y = refY, an = 5, w = osc_geo.w, h = user_opts.persistentprogressheight}
         lo.style = osc_styles.seekbar_fg
-        lo.slider.gap = 7
+        lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
         lo.slider.tooltip_an = 0   
     end
 


### PR DESCRIPTION
Two styles:

* existing triangle style

<img width="1265" alt="Screenshot 2024-12-28 at 3 19 09 PM" src="https://github.com/user-attachments/assets/68357752-72fa-4e17-8e02-b5d41a1b5b16" />

* More subtle bar style

<img width="1279" alt="Screenshot 2024-12-28 at 3 17 45 PM" src="https://github.com/user-attachments/assets/c04ea99e-fd6f-456f-8b11-32a2795c88f5" />

Also slider gap should be computed from seekbar background height and seekbar height instead of redefining.