### PR TITLE
feat: improve hovered chapter display if thumbfast is disabled

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1193,7 +1193,7 @@ local function render_elements(master_ass)
 
                         -- chapter title tooltip on show_title=false and no thumbfast
                         -- add hovered chapter title above time code tooltip on seekbar hover
-                        if thumbfast.disabled and not user_opts.show_title then
+                        if thumbfast.disabled and not user_opts.show_title and not user_opts.show_chapter_title then
                             local osd_w = mp.get_property_number("osd-width")
                             local r_w, r_h = get_virt_scale_factor()
                             if osd_w then
@@ -2193,6 +2193,7 @@ local function osc_init()
             local chapter_title = (chapters[chapter_index + 1] and chapters[chapter_index + 1].title ~= "") and 
                 chapters[chapter_index + 1].title or locale.chapter .. ": " .. chapter_index + 1 .. "/" .. #chapters
             chapter_title = mp.command_native({"escape-ass", chapter_title})
+            chapter_title = (thumbfast.disabled and not user_opts.show_title) and (state.forced_title ~= nil and state.forced_title) or chapter_title
             return string.format(user_opts.chapter_fmt, chapter_title)
         end
         return "" -- fallback

--- a/modernz.lua
+++ b/modernz.lua
@@ -1192,14 +1192,26 @@ local function render_elements(master_ass)
                         end
 
                         -- chapter title tooltip on show_title=false and no thumbfast
-                        local tooltip_content = tooltiplabel
+                        -- add hovered chapter title above time code tooltip on seekbar hover
                         if thumbfast.disabled and not user_opts.show_title then
-                            if user_opts.chapter_fmt ~= "no" and state.touchingprogressbar then
-                                local dur = mp.get_property_number("duration", 0)
-                                if dur > 0 then
-                                    local ch = get_chapter(state.sliderpos * dur / 100)
-                                    if ch and ch.title and ch.title ~= "" then
-                                        tooltip_content = tooltip_content .. " • " .. string.format(user_opts.chapter_fmt, ch.title)
+                            local osd_w = mp.get_property_number("osd-width")
+                            local r_w, r_h = get_virt_scale_factor()
+                            if osd_w then
+                                if user_opts.chapter_fmt ~= "no" and state.touchingprogressbar then
+                                    local dur = mp.get_property_number("duration", 0)
+                                    if dur > 0 then
+                                        local ch = get_chapter(state.sliderpos * dur / 100)
+                                        if ch and ch.title and ch.title ~= "" then
+                                            local titleX = math.min(osd_w - (50 / r_w), math.max((60 / r_w), tx / r_w))
+                                            local titleY = ty - (user_opts.time_font_size * 1.3)
+
+                                            elem_ass:new_event()
+                                            elem_ass:pos(titleX * r_w, titleY)
+                                            elem_ass:an(2)
+                                            elem_ass:append(slider_lo.tooltip_style)
+                                            ass_append_alpha(elem_ass, slider_lo.alpha, 0)
+                                            elem_ass:append(string.format(user_opts.chapter_fmt, ch.title))
+                                        end
                                     end
                                 end
                             end
@@ -1211,7 +1223,7 @@ local function render_elements(master_ass)
                         elem_ass:an(an)
                         elem_ass:append(slider_lo.tooltip_style)
                         ass_append_alpha(elem_ass, slider_lo.alpha, 0)
-                        elem_ass:append(tooltip_content)
+                        elem_ass:append(tooltiplabel)
                     elseif element.thumbnailable and thumbfast.available then
                         mp.commandv("script-message-to", "thumbfast", "clear")
                     end


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/285

- If `show_title` and `show_chapter_title` are disabled and `thumbfast` is not used, show hovered chapter title above the time code tooltip instead of appending it in the same time code line
- Align a min and max value so that on hover on end/start, chapter title tooltip doesn't go out of bound

![image](https://github.com/user-attachments/assets/f0023510-eb6c-4985-a89b-be918891a11c)

- if `show_title` and `thumbfast` are disabled, but `show_chapter_title` is enabled, replace `chapter_title` with hovered chapter. Similar to how `title` is changed on chapter hover, if `show_title` is enabled and `thumbfast` is disabled.

![image](https://github.com/user-attachments/assets/54a1932c-b6f6-4c05-9fe8-f4943d2c7995)