### PR TITLE
feat: when osc visibility is set to always, apply osc margins to show menus above it

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3643,6 +3643,7 @@ opt.read_options(user_opts, "modernz", function(changed)
     request_tick()
     visibility_mode(user_opts.visibility, true)
     update_duration_watch()
+    update_margins()
     request_init()
 end)
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -746,7 +746,7 @@ local function update_margins()
     local margins = osc_param.video_margins
 
     -- Don't use margins if it's visible only temporarily.
-    if not state.osc_visible or
+    if not state.osc_visible or get_hidetimeout() >= 0 or
        (state.fullscreen and not user_opts.showfullscreen) or
        (not state.fullscreen and not user_opts.showwindowed)
     then

--- a/modernz.lua
+++ b/modernz.lua
@@ -2207,19 +2207,25 @@ local function osc_init()
     ne.eventresponder["shift+mbtn_left_down"] = command_callback(user_opts.title_mbtn_mid_command)
 
     -- Chapter title (above seekbar)
-    local chapter_index = mp.get_property_number("chapter", -1)
     ne = new_element("chapter_title", "button")
-    ne.visible = chapter_index >= 0
+    ne.visible = mp.get_property_number("chapter", -1) >= 0
     ne.content = function()
-        if user_opts.chapter_fmt ~= "no" and chapter_index >= 0 then
-            local chapters = mp.get_property_native("chapter-list", {})
-            local chapter_title = (chapters[chapter_index + 1] and chapters[chapter_index + 1].title ~= "") and 
-                chapters[chapter_index + 1].title or locale.chapter .. ": " .. chapter_index + 1 .. "/" .. #chapters
-            chapter_title = mp.command_native({"escape-ass", chapter_title})
-            chapter_title = (thumbfast.disabled and not user_opts.show_title) and (state.forced_title ~= nil and state.forced_title) or chapter_title
-            return string.format(user_opts.chapter_fmt, chapter_title)
+        local chapter_index = mp.get_property_number("chapter", -1)
+        if user_opts.chapter_fmt == "no" or chapter_index < 0 then
+            return ""
         end
-        return "" -- fallback
+
+        local chapters = mp.get_property_native("chapter-list", {})
+        local chapter_data = chapters[chapter_index + 1]
+        local chapter_title = chapter_data and chapter_data.title ~= "" and chapter_data.title
+            or string.format("%s: %d/%d", locale.chapter, chapter_index + 1, #chapters)
+
+        chapter_title = mp.command_native({"escape-ass", chapter_title})
+        if thumbfast.disabled and not user_opts.show_title and state.forced_title then
+            chapter_title = state.forced_title
+        end
+
+        return string.format(user_opts.chapter_fmt, chapter_title)
     end
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.chapter_title_mbtn_left_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.chapter_title_mbtn_right_command)

--- a/modernz.lua
+++ b/modernz.lua
@@ -3555,7 +3555,11 @@ end)
 
 mp.register_script_message("osc-visibility", visibility_mode)
 mp.register_script_message("osc-show", show_osc)
-mp.register_script_message("osc-hide", function() osc_visible(false) end)
+mp.register_script_message("osc-hide", function() 
+    if user_opts.visibility == "auto" then
+        osc_visible(false)
+    end
+end)
 mp.add_key_binding(nil, "visibility", function() visibility_mode("cycle") end)
 mp.add_key_binding(nil, "progress-toggle", function()
     user_opts.persistentprogress = not user_opts.persistentprogress

--- a/modernz.lua
+++ b/modernz.lua
@@ -2851,7 +2851,6 @@ local function osc_init()
 
     --do something with the elements
     prepare_elements()
-    update_margins()
 end
 
 local function show_osc()

--- a/modernz.lua
+++ b/modernz.lua
@@ -2609,7 +2609,7 @@ local function osc_init()
         return state.buffering and locale.buffering .. ": " .. mp.get_property("cache-buffering-state") .. "%" or cache_time
     end
     ne.tooltip_style = osc_styles.tooltip
-    ne.tooltipF = (user_opts.tooltip_hints and cache_state_ranges) and locale.cache or ""
+    ne.tooltipF = (user_opts.tooltip_hints and cache_enabled()) and locale.cache or ""
 
     -- cache info speed
     ne = new_element("cache_info_speed", "button")

--- a/modernz.lua
+++ b/modernz.lua
@@ -202,24 +202,24 @@ local user_opts = {
     title_mbtn_right_command = "show-text ${path}",
 
     -- playlist button mouse actions
-    playlist_mbtn_left_command = "script-binding select/select-playlist",
+    playlist_mbtn_left_command = "script-binding select/select-playlist; script-message-to modernz osc-hide",
     playlist_mbtn_right_command = "show-text ${playlist} 3000",
 
     -- volume mouse actions
     vol_ctrl_mbtn_left_command = "no-osd cycle mute",
-    vol_ctrl_mbtn_right_command = "script-binding select/select-audio-device",
+    vol_ctrl_mbtn_right_command = "script-binding select/select-audio-device; script-message-to modernz osc-hide",
     vol_ctrl_wheel_down_command = "no-osd add volume -5",
     vol_ctrl_wheel_up_command = "no-osd add volume 5",
 
     -- audio button mouse actions
-    audio_track_mbtn_left_command = "script-binding select/select-aid",
+    audio_track_mbtn_left_command = "script-binding select/select-aid; script-message-to modernz osc-hide",
     audio_track_mbtn_mid_command = "cycle audio down",
     audio_track_mbtn_right_command = "cycle audio",
     audio_track_wheel_down_command = "cycle audio",
     audio_track_wheel_up_command = "cycle audio down",
 
     -- subtitle button mouse actions
-    sub_track_mbtn_left_command = "script-binding select/select-sid",
+    sub_track_mbtn_left_command = "script-binding select/select-sid; script-message-to modernz osc-hide",
     sub_track_mbtn_mid_command = "cycle sub down",
     sub_track_mbtn_right_command = "cycle sub",
     sub_track_wheel_down_command = "cycle sub",
@@ -228,24 +228,24 @@ local user_opts = {
     -- chapter skip buttons mouse actions
     chapter_prev_mbtn_left_command = "add chapter -1",
     chapter_prev_mbtn_mid_command = "show-text ${chapter-list} 3000",
-    chapter_prev_mbtn_right_command = "script-binding select/select-chapter",
+    chapter_prev_mbtn_right_command = "script-binding select/select-chapter; script-message-to modernz osc-hide",
 
     chapter_next_mbtn_left_command = "add chapter 1",
     chapter_next_mbtn_mid_command = "show-text ${chapter-list} 3000",
-    chapter_next_mbtn_right_command = "script-binding select/select-chapter",
+    chapter_next_mbtn_right_command = "script-binding select/select-chapter; script-message-to modernz osc-hide",
 
     -- chapter title (below seekbar) mouse actions
-    chapter_title_mbtn_left_command = "script-binding select/select-chapter",
+    chapter_title_mbtn_left_command = "script-binding select/select-chapter; script-message-to modernz osc-hide",
     chapter_title_mbtn_right_command = "show-text ${chapter-list} 3000",
 
     -- playlist skip buttons mouse actions
     playlist_prev_mbtn_left_command = "playlist-prev",
     playlist_prev_mbtn_mid_command = "show-text ${playlist} 3000",
-    playlist_prev_mbtn_right_command = "script-binding select/select-playlist",
+    playlist_prev_mbtn_right_command = "script-binding select/select-playlist; script-message-to modernz osc-hide",
 
     playlist_next_mbtn_left_command = "playlist-next",
     playlist_next_mbtn_mid_command = "show-text ${playlist} 3000",
-    playlist_next_mbtn_right_command = "script-binding select/select-playlist",
+    playlist_next_mbtn_right_command = "script-binding select/select-playlist; script-message-to modernz osc-hide",
 
     -- fullscreen button mouse actions
     fullscreen_mbtn_left_command = "cycle fullscreen",


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/302

- Use osc margins to show select menus and console above osc, when `visibility=always`
- Change z depth of osc to `1000` instead of `-1`
- When osc is visible, don't spam margins (verbose)
- Don't force hide osc with menus if osc visibility is set to always
- Remove unnecessary `request_init()` calls within `osc_init()`
- Apply osc margins within `osc_init()`
- Add `cache_enabled()` helper
- Don't use margins if osc is visible only temporarily
- Update chapter title to the current playing chapter
  - Since `request_init()` was used to update it (not sure why), it stopped working after its removal. Simply letting the content function handle it resolves the issue.
- Show `cache_info` tooltip on hover using the new cache helper function