### PR TITLE
feat: add options for thumbnail rounded corners and outline color

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sleek and modern OSC for [mpv](https://mpv.io/), this project is a fork of ModernX designed to enhance functionality by adding more features, all while preserving the core standards of mpv's OSC.
 
-![modernz_osc](https://github.com/user-attachments/assets/ef4ad6aa-2545-4aa4-b5e9-5e2c555ccc4d)
+![ModernZ_osc](https://github.com/user-attachments/assets/ca350c5c-14a5-4558-8a12-a9c2b05cba9a)
 
 <p align="center">
     <a href="#installation"><strong>Installation »</strong></a>
@@ -22,7 +22,7 @@ A sleek and modern OSC for [mpv](https://mpv.io/), this project is a fork of Mod
 
 - 🎨 Modern, customizable interface [[options](#configuration)]
 - 📷 Image Viewer mode with zoom controls [[details](/docs/IMAGE_VIEWER.md)]
-- 🎛️ Buttons: download, playlist, speed control, screenshot, pin, loop and more. [[details](/docs/CONTROLS.md)]
+- 🎛️ Buttons: download, playlist, speed control, screenshot, pin, loop, cache and more. [[details](/docs/CONTROLS.md)]
 - 📄 Interactive menus for playlist, subtitles, chapters, audio tracks and audio devices [[details](#interactive-menus)]
 - 🌐 Multi-language support with JSON [locale](#translations) integration
 - ⌨️ Configurable controls [[details](#controls)]
@@ -189,7 +189,7 @@ For even more useful scripts, check out the [mpv User Scripts Wiki](https://gith
 - To eliminate old bugs and redundancy within the code
     - Which allows other `Modern` forks to use ModernZ as a base, such as [zydezu/ModernX](https://github.com/zydezu/ModernX). [[Reference](https://github.com/zydezu/ModernX/releases/tag/0.3.9)]
 
-In essence, to modernize and revive the `Modern` origin.
+In essence, to maintain and revive the `modern-osc` origin.
 
 Having said that, ModernZ still uses parts of the old code, and every previous and current fork author and contributor deserve credit (including mpv's stock osc), that is why they're mentioned in detail.
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -136,10 +136,12 @@ Create `modernz.conf` in your mpv script-opts directory:
 | held_element_color          | `#999999` | color of the element when held down (pressed)                                                   |
 | hover_effect_color          | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                |
 | thumbnail_border_color      | `#111111` | color of the border for thumbnails (with thumbfast)                                             |
+| thumbnail_border_outline    | `#404040` | color of the border outline for thumbnails                                                      |
 | fade_alpha                  | 130       | alpha of the OSC background box                                                                 |
 | fade_blur_strength          | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render |
 | window_fade_alpha           | 75        | alpha of the window title bar                                                                   |
-| thumbnail_border            | 2         | width of the thumbnail border (for thumbfast)                                                   |
+| thumbnail_border            | 3         | width of the thumbnail border (for thumbfast)                                                   |
+| thumbnail_border_radius     | 3         | rounded corner radius for thumbnail border (0 to disable)                                       |
 
 ### Button hover effects
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -204,6 +204,8 @@ held_element_color=#999999
 hover_effect_color=#FB8C00
 # color of the border for thumbnails (with thumbfast)
 thumbnail_border_color=#111111
+# color of the border outline for thumbnails
+thumbnail_border_outline=#404040
 
 # alpha of the OSC background box
 fade_alpha=130
@@ -212,7 +214,9 @@ fade_blur_strength=100
 # alpha of the window title bar
 window_fade_alpha=75
 # width of the thumbnail border (for thumbfast)
-thumbnail_border=2
+thumbnail_border=3
+# rounded corner radius for thumbnail border (0 to disable)
+thumbnail_border_radius=3
 
 # Button hover effects
 # active button hover effects: "glow", "size", "color"; can use multiple separated by commas

--- a/modernz.lua
+++ b/modernz.lua
@@ -137,11 +137,13 @@ local user_opts = {
     held_element_color = "#999999",        -- color of the element when held down (pressed)
     hover_effect_color = "#FB8C00",        -- color of a hovered button when hover_effect includes "color"
     thumbnail_border_color = "#111111",    -- color of the border for thumbnails (with thumbfast)
+    thumbnail_border_outline = "#404040",  -- color of the border outline for thumbnails
 
     fade_alpha = 130,                      -- alpha of the OSC background box
     fade_blur_strength = 100,              -- blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
     window_fade_alpha = 75,                -- alpha of the window title bar
-    thumbnail_border = 2,                  -- width of the thumbnail border (for thumbfast)
+    thumbnail_border = 3,                  -- width of the thumbnail border (for thumbfast)
+    thumbnail_border_radius = 3,           -- rounded corner radius for thumbnail border (0 to disable)
 
     -- Button hover effects
     hover_effect = "size,glow,color",      -- active button hover effects: "glow", "size", "color"; can use multiple separated by commas
@@ -443,7 +445,7 @@ local function set_osc_styles()
         element_hover = "{" .. (contains(user_opts.hover_effect, "color") and "\\1c&H" .. osc_color_convert(user_opts.hover_effect_color) .. "&" or "") .."\\2c&HFFFFFF&" .. (contains(user_opts.hover_effect, "size") and string.format("\\fscx%s\\fscy%s", user_opts.hover_button_size, user_opts.hover_button_size) or "") .. "}",
         seekbar_bg = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.seekbarbg_color) .. "&}",
         seekbar_fg = "{\\blur1\\bord1\\1c&H" .. osc_color_convert(user_opts.seekbarfg_color) .. "&}",
-        thumbnail = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.thumbnail_border_color) .. "&\\3c&H000000&}",
+        thumbnail = "{\\blur0\\bord1\\1c&H" .. osc_color_convert(user_opts.thumbnail_border_color) .. "&\\3c&H" .. osc_color_convert(user_opts.thumbnail_border_outline) .. "&}",
         time = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.time_color) .. "&\\3c&H000000&\\fs" .. user_opts.time_font_size .. "\\fn" .. user_opts.font .. "}",
         cache = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.cache_info_color) .. "&\\3c&H000000&\\fs" .. user_opts.cache_info_font_size .. "\\fn" .. user_opts.font .. "}",
         title = "{\\blur1\\bord0.5\\1c&H" .. osc_color_convert(user_opts.title_color) .. "&\\3c&H0&\\fs".. user_opts.title_font_size .."\\q2\\fn" .. user_opts.font .. "}",
@@ -1180,7 +1182,11 @@ local function render_elements(master_ass)
                                     elem_ass:an(7)
                                     elem_ass:append(osc_styles.thumbnail)
                                     elem_ass:draw_start()
-                                    elem_ass:rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                                    if user_opts.thumbnail_border_radius and user_opts.thumbnail_border_radius > 0 then
+                                        elem_ass:round_rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h, user_opts.thumbnail_border_radius)
+                                    else
+                                        elem_ass:rect_cw(-thumbPad * r_w, -thumbPad * r_h, (thumbfast.width + thumbPad) * r_w, (thumbfast.height + thumbPad) * r_h)
+                                    end
                                     elem_ass:draw_stop()
 
                                     -- force tooltip to be centered on the thumb, even at far left/right of screen
@@ -3601,7 +3607,8 @@ local function validate_user_opts()
         user_opts.middle_buttons_color, user_opts.playpause_color, user_opts.window_title_color, 
         user_opts.window_controls_color, user_opts.held_element_color, user_opts.thumbnail_border_color, 
         user_opts.chapter_title_color, user_opts.seekbar_cache_color, user_opts.hover_effect_color,
-        user_opts.windowcontrols_close_hover, user_opts.windowcontrols_minmax_hover, user_opts.cache_info_color
+        user_opts.windowcontrols_close_hover, user_opts.windowcontrols_minmax_hover, user_opts.cache_info_color,
+        user_opts.thumbnail_border_outline,
     }
 
     for _, color in pairs(colors) do


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/108

![image](https://github.com/user-attachments/assets/9094e25e-00a8-4146-be1e-78a3be2e40ba)

**Changes**:
- Added options to control thumbnail border radius
- Added option to control thumbnail border outline color
- Changed `thumbnail_border` to `3` instead of `2`

```EditorConfig
# color of the border outline for thumbnails
thumbnail_border_outline=#404040
# rounded corner radius for thumbnail border (0 to disable)
thumbnail_border_radius=3
```