### PR TITLE
feat: add options to control window bar alpha

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -66,7 +66,6 @@ Create `modernz.conf` in your mpv script-opts directory:
 | -------------------- | ---------------- | ------------------------------------------------------------------------- |
 | window_title         | no               | show window title in borderless/fullscreen mode                           |
 | window_controls      | yes              | show window controls (close, minimize, maximize) in borderless/fullscreen |
-| title_bar_box        | no               | show title bar as a box instead of a black fade                           |
 | windowcontrols_title | `${media-title}` | same as title but for window_top_bar                                      |
 
 ### Subtitle display settings
@@ -115,33 +114,34 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Colors and style
 
-| Option                      | Value     | Description                                                                                     |
-| --------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
-| osc_color                   | `#000000` | accent color of the OSC and title bar                                                           |
-| window_title_color          | `#FFFFFF` | color of the title in borderless/fullscreen mode                                                |
-| window_controls_color       | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode          |
-| windowcontrols_close_hover  | `#E81123` | color of close window control on hover                                                          |
-| windowcontrols_minmax_hover | `#FFD700` | color of min/max window controls on hover                                                       |
-| title_color                 | `#FFFFFF` | color of the title (above seekbar)                                                              |
-| seekbarfg_color             | `#FB8C00` | color of the seekbar progress and handle                                                        |
-| seekbarbg_color             | `#94754F` | color of the remaining seekbar                                                                  |
-| seekbar_cache_color         | `#918F8E` | color of the cache ranges on the seekbar                                                        |
-| volumebar_match_seek_color  | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                        |
-| time_color                  | `#FFFFFF` | color of the timestamps (below seekbar)                                                         |
-| chapter_title_color         | `#FFFFFF` | color of the chapter title (above seekbar)                                                      |
-| cache_info_color            | `#FFFFFF` | color of the cache information                                                                  |
-| side_buttons_color          | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                                    |
-| middle_buttons_color        | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                         |
-| playpause_color             | `#FFFFFF` | color of the play/pause button                                                                  |
-| held_element_color          | `#999999` | color of the element when held down (pressed)                                                   |
-| hover_effect_color          | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                |
-| thumbnail_border_color      | `#111111` | color of the border for thumbnails (with thumbfast)                                             |
-| thumbnail_border_outline    | `#404040` | color of the border outline for thumbnails                                                      |
-| fade_alpha                  | 130       | alpha of the OSC background box                                                                 |
-| fade_blur_strength          | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render |
-| window_fade_alpha           | 75        | alpha of the window title bar                                                                   |
-| thumbnail_border            | 3         | width of the thumbnail border (for thumbfast)                                                   |
-| thumbnail_border_radius     | 3         | rounded corner radius for thumbnail border (0 to disable)                                       |
+| Option                      | Value     | Description                                                                                       |
+| --------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| osc_color                   | `#000000` | accent color of the OSC and title bar                                                             |
+| window_title_color          | `#FFFFFF` | color of the title in borderless/fullscreen mode                                                  |
+| window_controls_color       | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode            |
+| windowcontrols_close_hover  | `#E81123` | color of close window control on hover                                                            |
+| windowcontrols_minmax_hover | `#FFD700` | color of min/max window controls on hover                                                         |
+| title_color                 | `#FFFFFF` | color of the title (above seekbar)                                                                |
+| seekbarfg_color             | `#FB8C00` | color of the seekbar progress and handle                                                          |
+| seekbarbg_color             | `#94754F` | color of the remaining seekbar                                                                    |
+| seekbar_cache_color         | `#918F8E` | color of the cache ranges on the seekbar                                                          |
+| volumebar_match_seek_color  | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
+| time_color                  | `#FFFFFF` | color of the timestamps (below seekbar)                                                           |
+| chapter_title_color         | `#FFFFFF` | color of the chapter title (above seekbar)                                                        |
+| cache_info_color            | `#FFFFFF` | color of the cache information                                                                    |
+| side_buttons_color          | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                                      |
+| middle_buttons_color        | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                           |
+| playpause_color             | `#FFFFFF` | color of the play/pause button                                                                    |
+| held_element_color          | `#999999` | color of the element when held down (pressed)                                                     |
+| hover_effect_color          | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                  |
+| thumbnail_border_color      | `#111111` | color of the border for thumbnails (with thumbfast)                                               |
+| thumbnail_border_outline    | `#404040` | color of the border outline for thumbnails                                                        |
+| fade_alpha                  | 130       | alpha of the OSC background box (0 to disable)                                                    |
+| fade_blur_strength          | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render   |
+| window_fade_alpha           | 75        | alpha of the window title bar (0 to disable)                                                      |
+| window_fade_blur_strength   | 100       | blur strength for the window title bar. caution: high values can take a lot of CPU time to render |
+| thumbnail_border            | 3         | width of the thumbnail border (for thumbfast)                                                     |
+| thumbnail_border_radius     | 3         | rounded corner radius for thumbnail border (0 to disable)                                         |
 
 ### Button hover effects
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -83,8 +83,6 @@ tooltip_font_size=14
 window_title=no
 # show window controls (close, minimize, maximize) in borderless/fullscreen
 window_controls=yes
-# show title bar as a box instead of a black fade
-title_bar_box=no
 # same as title but for window_top_bar
 windowcontrols_title=${media-title}
 
@@ -211,8 +209,10 @@ thumbnail_border_outline=#404040
 fade_alpha=130
 # blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
 fade_blur_strength=100
-# alpha of the window title bar
+# alpha of the window title bar (0 to disable)
 window_fade_alpha=75
+# blur strength for the window title bar. caution: high values can take a lot of CPU time to render
+window_fade_blur_strength=100
 # width of the thumbnail border (for thumbfast)
 thumbnail_border=3
 # rounded corner radius for thumbnail border (0 to disable)

--- a/modernz.lua
+++ b/modernz.lua
@@ -68,7 +68,6 @@ local user_opts = {
     -- Title bar settings
     window_title = false,                  -- show window title in borderless/fullscreen mode
     window_controls = true,                -- show window controls (close, minimize, maximize) in borderless/fullscreen
-    title_bar_box = false,                 -- show title bar as a box instead of a black fade
     windowcontrols_title = "${media-title}", -- same as title but for windowcontrols
 
     -- Subtitle display settings
@@ -139,9 +138,10 @@ local user_opts = {
     thumbnail_border_color = "#111111",    -- color of the border for thumbnails (with thumbfast)
     thumbnail_border_outline = "#404040",  -- color of the border outline for thumbnails
 
-    fade_alpha = 130,                      -- alpha of the OSC background box
+    fade_alpha = 130,                      -- alpha of the OSC background (0 to disable)
     fade_blur_strength = 100,              -- blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
-    window_fade_alpha = 75,                -- alpha of the window title bar
+    window_fade_alpha = 75,                -- alpha of the window title bar (0 to disable)
+    window_fade_blur_strength = 100,       -- blur strength for the window title bar. caution: high values can take a lot of CPU time to render
     thumbnail_border = 3,                  -- width of the thumbnail border (for thumbfast)
     thumbnail_border_radius = 3,           -- rounded corner radius for thumbnail border (0 to disable)
 
@@ -440,8 +440,8 @@ local function set_osc_styles()
     local midbuttons_size = user_opts.midbuttons_size or 24
     local sidebuttons_size = user_opts.sidebuttons_size or 24
     osc_styles = {
-        background_bar = "{\\1c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
         box_bg = "{\\blur" .. user_opts.fade_blur_strength .. "\\bord" .. user_opts.fade_alpha .. "\\1c&H000000&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
+        window_box_bg = "{\\blur" .. user_opts.window_fade_blur_strength .. "\\bord" .. user_opts.window_fade_alpha .. "\\1c&H000000&\\3c&H" .. osc_color_convert(user_opts.osc_color) .. "&}",
         chapter_title = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.chapter_title_color) .. "&\\3c&H000000&\\fs" .. user_opts.chapter_title_font_size .. "\\fn" .. user_opts.font .. "}",
         control_1 = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.playpause_color) .. "&\\3c&HFFFFFF&\\fs" .. playpause_size .. "\\fn" .. iconfont .. "}",
         control_2 = "{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.middle_buttons_color) .. "&\\3c&HFFFFFF&\\fs" .. midbuttons_size .. "\\fn" .. iconfont .. "}",
@@ -1580,16 +1580,6 @@ local function window_controls()
 
     local lo
 
-    -- Background Bar
-    if user_opts.title_bar_box then
-        new_element("wcbar", "box")
-        lo = add_layout("wcbar")
-        lo.geometry = wc_geo
-        lo.layer = 10
-        lo.style = osc_styles.background_bar
-        lo.alpha[1] = user_opts.window_fade_alpha
-    end
-
     local button_y = wc_geo.y - (wc_geo.h / 2)
     local first_geo = {x = controlbox_left + 25, y = button_y, an = 5, w = 50, h = wc_geo.h}
     local second_geo = {x = controlbox_left + 75, y = button_y, an = 5, w = 49, h = wc_geo.h}
@@ -1716,11 +1706,12 @@ layouts["modern"] = function ()
 
     local top_titlebar = window_controls_enabled() and (user_opts.window_title or user_opts.window_controls)
 
-    if not user_opts.title_bar_box and ((user_opts.window_top_bar == "yes" or not (state.border and state.title_bar)) or state.fullscreen) and top_titlebar then
+    -- Window controls
+    if ((user_opts.window_top_bar == "yes" or not (state.border and state.title_bar)) or state.fullscreen) and top_titlebar then
         new_element("title_alpha_bg", "box")
         lo = add_layout("title_alpha_bg")
         lo.geometry = {x = posX, y = -100, an = 7, w = osc_w, h = -1}
-        lo.style = osc_styles.box_bg
+        lo.style = osc_styles.window_box_bg
         lo.layer = 10
         lo.alpha[3] = 0
     end
@@ -1993,11 +1984,12 @@ layouts["modern-image"] = function ()
 
     local top_titlebar = window_controls_enabled() and (user_opts.window_title or user_opts.window_controls)
 
-    if not user_opts.title_bar_box and ((user_opts.window_top_bar == "yes" or not (state.border and state.title_bar)) or state.fullscreen) and top_titlebar then
+    -- Window controls
+    if ((user_opts.window_top_bar == "yes" or not (state.border and state.title_bar)) or state.fullscreen) and top_titlebar then
         new_element("title_alpha_bg", "box")
         lo = add_layout("title_alpha_bg")
         lo.geometry = {x = posX, y = -100, an = 7, w = osc_w, h = -1}
-        lo.style = osc_styles.box_bg
+        lo.style = osc_styles.window_box_bg
         lo.layer = 10
         lo.alpha[3] = 0
     end


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/307

**Changes**:
- Remove deprecated `title_bar_box` option
- Fix `window_fade_alpha` behavior to work properly. (0 to disable)
- Add `window_fade_blur_strength` to control window bar blur strength separately from osc

```EditorConfig
# alpha of the window title bar (0 to disable)
window_fade_alpha=75
# blur strength for the window title bar. caution: high values can take a lot of CPU time to render
window_fade_blur_strength=100
```
