### PR TITLE
fix: don't hide osc on mouse leave when paused and keeponpause

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3147,9 +3147,7 @@ local function render()
         local timeout = state.showtime + (get_hidetimeout() / 1000) - now
         if timeout <= 0 and get_touchtimeout() <= 0 then
             if state.active_element == nil and not mouse_over_osc then
-                if not (state.paused and user_opts.keeponpause) then
-                    hide_osc()
-                end
+                hide_osc()
             end
         else
             -- the timer is only used to recheck the state and to possibly run
@@ -3505,9 +3503,14 @@ mp.observe_property("pause", "bool", function(name, enabled)
             -- save mode if a temporary change is needed
             if not state.temp_visibility_mode and user_opts.visibility ~= "always" then
                 state.temp_visibility_mode = user_opts.visibility
-                visibility_mode("auto", true)
             end
-            show_osc()
+            
+            if user_opts.keeponpause then
+                -- set visibility to "always" temporarily
+                visibility_mode("always", true)
+            else
+                show_osc()
+            end
         else
             -- restore mode if it was changed temporarily
             if state.temp_visibility_mode then


### PR DESCRIPTION
The old `modern-osc` implementation of this is kind of weird. It worked, but not in the best way.

**Old behavior**:
- `showonpause` and `paused` then trigger `show_osc()`
- `keeponpause` and `paused` force no `hide_osc()` and force constant call of `show_osc()`

Which is ineffective because that behavior even with `keeponpause` enabled and `paused`, on mouse leave the osc will hide.

This fix unites `showonpause` and `keeponpause` into one function within observing the pause property instead of altering auto hide behavior.

Also, it changes `keeponpause` behavior so that it changes visibility to `always` temporarilty while paused, instead of forcing to not call `hide_osc()` and spam calling `show_osc()`