### PR TITLE
fix: be consistent with seekbar and thumbnail layer instead of assigning random layer levels

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1693,7 +1693,7 @@ layouts["modern"] = function ()
     lo = add_layout("seekbar")
     local seekbar_h = 18
     lo.geometry = {x = refX, y = refY - 72, an = 5, w = osc_geo.w - 50, h = seekbar_h}
-    lo.layer = 100
+    lo.layer = 51
     lo.style = osc_styles.seekbar_fg
     lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
     lo.slider.tooltip_style = osc_styles.tooltip


### PR DESCRIPTION
The problem was that sometimes the thumbnail background and title would overlap with each other.

This is because they have the same layer level, which by default is 50.
```lua
-- set layout defaults
elements[name].layout.layer = 50
```

Instead of randomly assigning a high layer number to seekbar, be consistent and simply increment by one.
```PowerShell
PS C:\> mpv 'E:\clips\test_video.mp4'
   modernz: Seekbar layer: 51
   modernz: Title layer: 50
   modernz: Chapter layer: 50
```

This should fix thumbnail and title overlapping, because the thumbnail is generated as a seekbar tooltip, and now it will have a higher layer level.

In the future I might implement an automated increment to seekbar layer, by using something like:
```lua
lo.layer = lo.layer + 1
```

As of now, this change should suffice, as layering is rarely an issue.