### PR TITLE
fix: improve time codes hitbox and narrow window visibility

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -199,7 +199,7 @@ Useful when adjusting font size or type, this will help you change the affected 
 | time_codes_centered_height    | 57     | time codes height position with portrait window                        |
 | tooltip_height_offset         | 2      | tooltip height position offset                                         |
 | tooltip_left_offset           | 5      | if tooltip contains many characters, it is moved to the left by offset |
-| portrait_window_trigger       | 930    | portrait window width trigger to move some elements                    |
+| portrait_window_trigger       | 1000   | portrait window width trigger to move some elements                    |
 | hide_volume_bar_trigger       | 1150   | hide volume bar trigger window width                                   |
 | notitle_osc_h_offset          | 25     | osc height offset if title above seekbar is disabled                   |
 | nochapter_osc_h_offset        | 10     | osc height offset if chapter title is disabled or doesn't exist        |

--- a/modernz.conf
+++ b/modernz.conf
@@ -292,7 +292,7 @@ tooltip_height_offset=2
 # if tooltip contains many characters, it is moved to the left by offset
 tooltip_left_offset=5
 # portrait window width trigger to move some elements
-portrait_window_trigger=930
+portrait_window_trigger=1000
 # hide volume bar trigger window width
 hide_volume_bar_trigger=1150
 # osc height offset if title above seekbar is disabled

--- a/modernz.lua
+++ b/modernz.lua
@@ -1853,7 +1853,7 @@ layouts["modern"] = function ()
         - (audio_track and 0 or 100)
     )
     lo = add_layout("time_codes")
-    lo.geometry = {x = (narrow_win and refX or time_codes_x), y = refY - (narrow_win and user_opts.time_codes_centered_height or user_opts.time_codes_height), an = (narrow_win and 5 or 4), w = time_codes_width, h = 15}
+    lo.geometry = {x = (narrow_win and refX or time_codes_x), y = refY - (narrow_win and user_opts.time_codes_centered_height or user_opts.time_codes_height), an = (narrow_win and 5 or 4), w = time_codes_width, h = user_opts.time_font_size}
     lo.style = osc_styles.time
 
     -- Fullscreen/Info/Pin/Screenshot/Loop/Speed


### PR DESCRIPTION
**Changes**:
- Improve time codes hitbox in different scenarios
- Improve narrow window trigger

**Known issues**: [old issues, not caused by this PR]
- Hitbox width will not be accurate if font size for time codes changes drastically
  - Introduce width offset for user to control as an option in the future? ie: `10` or `-10`
- ~~Using `time_format=dynamic`, with a video longer than one hour, once playback time reaches one hour or more, the hitbox doesn't get changed to match.~~
  - ~~If you invoke milliseconds (right click) on/off, it is fixed~~
  - ~~This hints that hitbox value isn't updated and needs a measure to `request_init()`, which is very expensive with playback time~~
  - ~~I don't want to rush implementing a fix for this, so it will be added in a separate PR when a proper method is found~~

**Applied fix for time codes width hitbox in dynamic time format**: https://github.com/Samillion/ModernZ/commit/01651f03475cf28b3f008890426fe9d284f22910
I'm certain there is a better method, but nothing comes to mind. This works and doesn't spam call `request_init()` needlessly.
