### PR TITLE
pause-indicator: add fluent_icon_size option

### DIFF
--- a/extras/pause-indicator-lite/README.md
+++ b/extras/pause-indicator-lite/README.md
@@ -35,7 +35,8 @@ To adjust them you can either:
 | `triangle_height`        | 80          | height of triangle (play icon)                                                                                                       |
 | `flash_play_icon`        | yes         | flash play icon on unpause (best with pause indicator icon)                                                                          |
 | `flash_icon_timeout`     | 0.3         | timeout (seconds) for flash icon                                                                                                     |
-| `fluent_icons`           | no          | requires `fonts/fluent-system-icons.ttf` [[details](https://github.com/Samillion/ModernZ/pull/335)]                                  |
+| `fluent_icons`           | no          | requires `fonts/fluent-system-icons.ttf` [[details](https://github.com/Samillion/ModernZ/pull/336)]                                  |
+| `fluent_icon_size`       | 90          | fluent icon size                                                                                                                     |
 
 ### How to install
 

--- a/extras/pause-indicator-lite/pause_indicator_lite.conf
+++ b/extras/pause-indicator-lite/pause_indicator_lite.conf
@@ -43,3 +43,5 @@ flash_icon_timeout=0.3
 # icon style used in ModernZ osc
 # requires fonts/fluent-system-icons.ttf
 fluent_icons=no
+# fluent icon size
+fluent_icon_size=90

--- a/extras/pause-indicator-lite/pause_indicator_lite.lua
+++ b/extras/pause-indicator-lite/pause_indicator_lite.lua
@@ -38,6 +38,7 @@ local options = {
 
     -- icon style used in ModernZ osc
     fluent_icons = false,            -- requires fonts/fluent-system-icons.ttf
+    fluent_icon_size = 90,           -- fluent icon size
 }
 
 local msg = require "mp.msg"
@@ -69,7 +70,7 @@ local function draw_rectangles()
     if options.fluent_icons then
         local pause_icon = "\238\163\140"
         return string.format([[{\\rDefault\\an5\\alpha&H%s\\bord%s\\1c&H%s&\\3c&H%s&\\fs%s\\fn%s}%s]],
-            icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.rectangles_height, icon_font, pause_icon)
+            icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.fluent_icon_size, icon_font, pause_icon)
     else
         return string.format([[{\\rDefault\\p1\\an5\\alpha&H%s\\bord%s\\1c&H%s&\\3c&H%s&}m 0 0 l %d 0 l %d %d l 0 %d m %d 0 l %d 0 l %d %d l %d %d{\\p0}]],
             icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.rectangles_width, options.rectangles_width, 
@@ -84,7 +85,7 @@ local function draw_triangle()
     if options.fluent_icons then
         local play_icon = "\238\166\143"
         return string.format([[{\\rDefault\\an5\\alpha&H%s\\bord%s\\1c&H%s&\\3c&H%s&\\fs%s\\fn%s}%s]],
-            icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.triangle_height, icon_font, play_icon)
+            icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.fluent_icon_size, icon_font, play_icon)
     else
         return string.format([[{\\rDefault\\p1\\an5\\alpha&H%s\\bord%s\\1c&H%s&\\3c&H%s&}m 0 0 l %d %d l 0 %d{\\p0}]],
             icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.triangle_width, options.triangle_height / 2, options.triangle_height)


### PR DESCRIPTION
### Changes
- add `fluent_icon_size` option

### Usage
The `fluent_icons` option requires the [fluent-system-icons.ttf](https://github.com/Samillion/ModernZ/blob/main/fluent-system-icons.ttf) font file, which is also used for ModernZ osc.

- To use the fluent icon style, set `fluent_icons` to `yes`
- To control icon size, adjust `fluent_icon_size` value, default is `90`
- Respects icon style options: `icon_color`, `icon_border_color`, `icon_border_width`, `icon_opacity`

### Preview
![fluent_indicators](https://github.com/user-attachments/assets/baeff211-6759-435a-a10d-fa614aba5019)

### File locations
```
mpv
├── fonts/
│   └── fluent-system-icons.ttf (optional) [required for fluent_icons]
├── script-opts
│   └── pause_indicator_lite.conf
└── scripts
    └── pause_indicator_lite.lua
```