### PR TITLE
feat: add visibility_modes option

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ For a full list of interactions, check out the [Button Interactions Guide](docs/
 ModernZ doesn't set keybinds by default to avoid interfering with your current setup. You can add keybinds in `input.conf` if you prefer:
 
 ```
-w   script-binding modernz/progress-toggle     # Toggle progress bar
-x   script-message-to modernz osc-show         # Show OSC
-y   script-message-to modernz osc-visibility   # Toggle visibility
-z   script-message-to modernz osc-idlescreen   # Toggle idle screen
+w   script-binding modernz/progress-toggle           # Toggle progress bar
+x   script-message-to modernz osc-show               # Show OSC
+y   script-message-to modernz osc-visibility cycle   # Cycle visibility modes
+z   script-message-to modernz osc-idlescreen         # Toggle idle screen
 ```
 
 ## Translations

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -180,12 +180,12 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Miscellaneous settings
 
-| Option                        | Value             | Description                                       |
-| ----------------------------- | ----------------- | ------------------------------------------------- |
-| visibility                    | auto              | only used at init to set visibility_mode(...)     |
-| visibility_modes              | never_auto_always | visibility modes to cycle through                 |
-| tick_delay                    | 0.03              | minimum interval between OSC redraws (in seconds) |
-| tick_delay_follow_display_fps | no                | use display FPS as the minimum redraw interval    |
+| Option                        | Value             | Description                                                   |
+| ----------------------------- | ----------------- | ------------------------------------------------------------- |
+| visibility                    | auto              | only used at init to set visibility_mode(...)                 |
+| visibility_modes              | never_auto_always | visibility modes to cycle through, modes are separated by `_` |
+| tick_delay                    | 0.03              | minimum interval between OSC redraws (in seconds)             |
+| tick_delay_follow_display_fps | no                | use display FPS as the minimum redraw interval                |
 
 ### Elements Position
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -180,11 +180,12 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Miscellaneous settings
 
-| Option                        | Value  | Description                                       |
-| ----------------------------- | ------ | ------------------------------------------------- |
-| visibility                    | auto   | only used at init to set visibility_mode(...)     |
-| tick_delay                    | 0.03   | minimum interval between OSC redraws (in seconds) |
-| tick_delay_follow_display_fps | no     | use display FPS as the minimum redraw interval    |
+| Option                        | Value             | Description                                       |
+| ----------------------------- | ----------------- | ------------------------------------------------- |
+| visibility                    | auto              | only used at init to set visibility_mode(...)     |
+| visibility_modes              | never_auto_always | visibility modes to cycle through                 |
+| tick_delay                    | 0.03              | minimum interval between OSC redraws (in seconds) |
+| tick_delay_follow_display_fps | no                | use display FPS as the minimum redraw interval    |
 
 ### Elements Position
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -269,6 +269,8 @@ persistentbuffer=no
 # Miscellaneous settings
 # only used at init to set visibility_mode(...)
 visibility=auto
+# visibility modes to cycle through
+visibility_modes=never_auto_always
 # minimum interval between OSC redraws (in seconds)
 tick_delay=0.03
 # use display FPS as the minimum redraw interval

--- a/modernz.conf
+++ b/modernz.conf
@@ -269,7 +269,7 @@ persistentbuffer=no
 # Miscellaneous settings
 # only used at init to set visibility_mode(...)
 visibility=auto
-# visibility modes to cycle through
+# visibility modes to cycle through, modes are separated by _
 visibility_modes=never_auto_always
 # minimum interval between OSC redraws (in seconds)
 tick_delay=0.03

--- a/modernz.lua
+++ b/modernz.lua
@@ -176,6 +176,7 @@ local user_opts = {
 
     -- Miscellaneous settings
     visibility = "auto",                   -- only used at init to set visibility_mode(...)
+    visibility_modes = "never_auto_always",-- visibility modes to cycle through
     tick_delay = 0.03,                     -- minimum interval between OSC redraws (in seconds)
     tick_delay_follow_display_fps = false, -- use display FPS as the minimum redraw interval
 
@@ -502,6 +503,7 @@ local state = {
     new_file_flag = false,                  -- flag to detect new file starts
     temp_visibility_mode = nil,             -- store temporary visibility mode state
     chapter_list = {},                      -- sorted by time
+    visibility_modes = {},                  -- visibility_modes to cycle through
     mute = false,
     looping = false,
     sliderpos = 0,
@@ -3452,12 +3454,14 @@ end
 -- the modes only affect internal variables and not stored on its own.
 local function visibility_mode(mode, no_osd)
     if mode == "cycle" then
-        if not state.enabled then
-            mode = "auto"
-        elseif user_opts.visibility ~= "always" then
-            mode = "always"
-        else
-            mode = "never"
+        for i, allowed_mode in ipairs(state.visibility_modes) do
+            if i == #state.visibility_modes then
+                mode = state.visibility_modes[1]
+                break
+            elseif user_opts.visibility == allowed_mode then
+                mode = state.visibility_modes[i + 1]
+                break
+            end
         end
     end
 
@@ -3487,6 +3491,7 @@ local function visibility_mode(mode, no_osd)
     mp.disable_key_bindings("input")
     mp.disable_key_bindings("window-controls")
     state.input_enabled = false
+
     update_margins()
     request_tick()
 end
@@ -3619,6 +3624,14 @@ local function validate_user_opts()
     for _, color in pairs(colors) do
         if color:find("^#%x%x%x%x%x%x$") == nil then
             msg.warn("'" .. color .. "' is not a valid color")
+        end
+    end
+
+    for str in string.gmatch(user_opts.visibility_modes, "([^_]+)") do
+        if str ~= "auto" and str ~= "always" and str ~= "never" then
+            msg.warn("Ignoring unknown visibility mode '" .. str .."' in list")
+        else
+            table.insert(state.visibility_modes, str)
         end
     end
 end


### PR DESCRIPTION
### Changes
- Add `visibility_modes` option
- Default: `never_auto_always`

### Usage
- The list of visibility modes to cycle through when calling the `osc-visibility cycle` script message
- Modes are separated by `_`

```EditorConfig
# modernz.conf
# cycle visibility between always and never only
visibility_modes=always_never
```

```EditorConfig
#  input.conf
v  script-message-to modernz osc-visibility cycle
```

From upstream mpv: https://github.com/mpv-player/mpv/pull/15734
