### PR TITLE
feat: add force_seek_tooltip option

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -26,19 +26,20 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### OSC behaviour and scaling
 
-| Option                  | Value | Description                                                |
-| ----------------------- | ----- | ---------------------------------------------------------- |
-| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement         |
-| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                    |
-| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade        |
-| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC    |
-| bottomhover             | yes   | show OSC only when hovering at the bottom                  |
-| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)           |
-| osc_on_seek             | no    | show OSC when seeking                                      |
-| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold) |
-| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)       |
-| scalewindowed           | 1.0   | osc scale factor when windowed                             |
-| scalefullscreen         | 1.0   | osc scale factor when fullscreen                           |
+| Option                  | Value | Description                                                             |
+| ----------------------- | ----- | ----------------------------------------------------------------------- |
+| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                      |
+| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                 |
+| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade                     |
+| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                 |
+| bottomhover             | yes   | show OSC only when hovering at the bottom                               |
+| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                        |
+| osc_on_seek             | no    | show OSC when seeking                                                   |
+| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)              |
+| force_seek_tooltip      | no    | force show seedkbar tooltip on mouse drag, even if not hovering seekbar |
+| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                    |
+| scalewindowed           | 1.0   | osc scale factor when windowed                                          |
+| scalefullscreen         | 1.0   | osc scale factor when fullscreen                                        |
 
 ### Elements display
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -26,20 +26,20 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### OSC behaviour and scaling
 
-| Option                  | Value | Description                                                             |
-| ----------------------- | ----- | ----------------------------------------------------------------------- |
-| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                      |
-| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                 |
-| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade                     |
-| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                 |
-| bottomhover             | yes   | show OSC only when hovering at the bottom                               |
-| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                        |
-| osc_on_seek             | no    | show OSC when seeking                                                   |
-| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)              |
-| force_seek_tooltip      | no    | force show seedkbar tooltip on mouse drag, even if not hovering seekbar |
-| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                    |
-| scalewindowed           | 1.0   | osc scale factor when windowed                                          |
-| scalefullscreen         | 1.0   | osc scale factor when fullscreen                                        |
+| Option                  | Value | Description                                                                                        |
+| ----------------------- | ----- | -------------------------------------------------------------------------------------------------- |
+| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                                                 |
+| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                                            |
+| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade                                                |
+| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                                            |
+| bottomhover             | yes   | show OSC only when hovering at the bottom                                                          |
+| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                                                   |
+| osc_on_seek             | no    | show OSC when seeking                                                                              |
+| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)                                         |
+| force_seek_tooltip      | no    | force show seekbar tooltip on mouse drag, even if not hovering seekbar, with `bottomhover` enabled |
+| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                                               |
+| scalewindowed           | 1.0   | osc scale factor when windowed                                                                     |
+| scalefullscreen         | 1.0   | osc scale factor when fullscreen                                                                   |
 
 ### Elements display
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -26,20 +26,20 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### OSC behaviour and scaling
 
-| Option                  | Value | Description                                                                                        |
-| ----------------------- | ----- | -------------------------------------------------------------------------------------------------- |
-| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                                                 |
-| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                                            |
-| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade                                                |
-| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                                            |
-| bottomhover             | yes   | show OSC only when hovering at the bottom                                                          |
-| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                                                   |
-| osc_on_seek             | no    | show OSC when seeking                                                                              |
-| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)                                         |
-| force_seek_tooltip      | no    | force show seekbar tooltip on mouse drag, even if not hovering seekbar, with `bottomhover` enabled |
-| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                                               |
-| scalewindowed           | 1.0   | osc scale factor when windowed                                                                     |
-| scalefullscreen         | 1.0   | osc scale factor when fullscreen                                                                   |
+| Option                  | Value | Description                                                            |
+| ----------------------- | ----- | ---------------------------------------------------------------------- |
+| hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                     |
+| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                |
+| fadeduration            | 250   | fade-out duration (in ms), set to `"0"` for no fade                    |
+| minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                |
+| bottomhover             | yes   | show OSC only when hovering at the bottom                              |
+| bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                       |
+| osc_on_seek             | no    | show OSC when seeking                                                  |
+| mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)             |
+| force_seek_tooltip      | no    | force show seekbar tooltip on mouse drag, even if not hovering seekbar |
+| vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                   |
+| scalewindowed           | 1.0   | osc scale factor when windowed                                         |
+| scalefullscreen         | 1.0   | osc scale factor when fullscreen                                       |
 
 ### Elements display
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -36,7 +36,7 @@ bottomhover_zone=130
 osc_on_seek=no
 # pause video while seeking with mouse move (on button hold)
 mouse_seek_pause=yes
-# force show seedkbar tooltip on mouse drag, even if not hovering seekbar
+# force show seekbar tooltip on mouse drag, even if not hovering seekbar
 force_seek_tooltip=no
 
 # scale osc with the video

--- a/modernz.conf
+++ b/modernz.conf
@@ -36,6 +36,8 @@ bottomhover_zone=130
 osc_on_seek=no
 # pause video while seeking with mouse move (on button hold)
 mouse_seek_pause=yes
+# force show seedkbar tooltip on mouse drag, even if not hovering seekbar
+force_seek_tooltip=no
 
 # scale osc with the video
 vidscale=auto

--- a/modernz.lua
+++ b/modernz.lua
@@ -39,7 +39,7 @@ local user_opts = {
     bottomhover_zone = 130,                -- height of hover zone for bottomhover (in pixels)
     osc_on_seek = false,                   -- show OSC when seeking
     mouse_seek_pause = true,               -- pause video while seeking with mouse move (on button hold)
-    force_seek_tooltip = false,            -- force show seedkbar tooltip on mouse drag, even if not hovering seekbar
+    force_seek_tooltip = false,            -- force show seekbar tooltip on mouse drag, even if not hovering seekbar
 
     vidscale = "auto",                     -- scale osc with the video
     scalewindowed = 1.0,                   -- osc scale factor when windowed


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/306

Force show seekbar tooltip (ie: thumbnail) on mouse drag, even if not hovering seekbar, while holding down mouse button.

### Changes
- Add `force_seek_tooltip` option
- Rename `playingWhilstSeeking` state to `playing_and_seeking`
- Rename `persistentprogresstoggle` state to `persistent_progress_toggle`
- Remove unused state `playingWhilstSeekingWaitingForEnd`
- Make `playing_and_seeking` state independent and not tied to `mouse_seek_pause` option
- Fix behavior of  `mouse_seek_pause` option when set to `no` and mouse drag then release mouse button
  - It used to pause the video on button release, now it doesn't
  - Now it only cycles pause if `mouse_seek_pause` is set to `yes`

### Usage
```EditorConfig
# modernz.conf
# enable the option to force seek tooltip
force_seek_tooltip=yes
```