### PR TITLE
feat: add osc_on_start option

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -36,6 +36,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | bottomhover             | yes   | show OSC only when hovering at the bottom                              |
 | bottomhover_zone        | 130   | height of hover zone for bottomhover (in pixels)                       |
 | osc_on_seek             | no    | show OSC when seeking                                                  |
+| osc_on_start            | no    | show OSC on start of every file                                        |
 | mouse_seek_pause        | yes   | pause video while seeking with mouse move (on button hold)             |
 | force_seek_tooltip      | no    | force show seekbar tooltip on mouse drag, even if not hovering seekbar |
 | vidscale                | auto  | scale osc with the video. (set to `"no"` to disable)                   |

--- a/modernz.conf
+++ b/modernz.conf
@@ -36,6 +36,8 @@ bottomhover=yes
 bottomhover_zone=130
 # show OSC when seeking
 osc_on_seek=no
+# show OSC on start of every file
+osc_on_start=no
 # pause video while seeking with mouse move (on button hold)
 mouse_seek_pause=yes
 # force show seekbar tooltip on mouse drag, even if not hovering seekbar

--- a/modernz.lua
+++ b/modernz.lua
@@ -39,6 +39,7 @@ local user_opts = {
     bottomhover = true,                    -- show OSC only when hovering at the bottom
     bottomhover_zone = 130,                -- height of hover zone for bottomhover (in pixels)
     osc_on_seek = false,                   -- show OSC when seeking
+    osc_on_start = false,                  -- show OSC on start of every file
     mouse_seek_pause = true,               -- pause video while seeking with mouse move (on button hold)
     force_seek_tooltip = false,            -- force show seekbar tooltip on mouse drag, even if not hovering seekbar
 
@@ -3340,6 +3341,9 @@ mp.register_event("file-loaded", function()
        else
             user_opts.seekbarkeyframes = false
        end
+    end
+    if user_opts.osc_on_start then
+        show_osc()
     end
 end)
 mp.register_event("start-file", request_init)


### PR DESCRIPTION
### Changes
- Add `osc_on_start` option to show osc on start of every file

### Usage
```EditorConfig
# modernz.conf
osc_on_start=yes
```

Fixes: https://github.com/Samillion/ModernZ/issues/345
