### PR TITLE
feat: add info_mbtn_left_command option

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -251,6 +251,7 @@ Customize the button function based on mouse actions.
 |                               | playlist_next_mbtn_right_command | `script-binding select/select-playlist; script-message-to modernz osc-hide`     |
 | Fullscreen Button             | fullscreen_mbtn_left_command     | `cycle fullscreen`                                                              |
 |                               | fullscreen_mbtn_right_command    | `cycle window-maximized`                                                        |
+| Info Button                   | info_mbtn_left_command           | `script-binding stats/display-page-1-toggle`                                    |
 
 ### Auto Profile
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -369,3 +369,6 @@ playlist_next_mbtn_right_command=script-binding select/select-playlist; script-m
 # fullscreen button mouse actions
 fullscreen_mbtn_left_command=cycle fullscreen
 fullscreen_mbtn_right_command=cycle window-maximized
+
+# info button mouse actions
+info_mbtn_left_command=script-binding stats/display-page-1-toggle

--- a/modernz.lua
+++ b/modernz.lua
@@ -256,6 +256,9 @@ local user_opts = {
     -- fullscreen button mouse actions
     fullscreen_mbtn_left_command = "cycle fullscreen",
     fullscreen_mbtn_right_command = "cycle window-maximized",
+
+    -- info button mouse actions
+    info_mbtn_left_command = "script-binding stats/display-page-1-toggle",
 }
 
 mp.observe_property("osc", "bool", function(name, value) if value == true then mp.set_property("osc", "no") end end)
@@ -2493,7 +2496,7 @@ local function osc_init()
     ne.tooltip_style = osc_styles.tooltip
     ne.tooltipF = user_opts.tooltip_hints and locale.stats_info or ""
     ne.visible = (osc_param.playresx >= 650 - outeroffset - (user_opts.fullscreen_button and 0 or 100))
-    ne.eventresponder["mbtn_left_up"] = function () mp.commandv("script-binding", "stats/display-page-1-toggle") end
+    ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.info_mbtn_left_command)
 
     --tog_ontop
     ne = new_element("tog_ontop", "button")


### PR DESCRIPTION
### Changes
- Add `info_mbtn_left_command` option

### Usage
```EditorConfig
# modernz.conf
info_mbtn_left_command=script-binding stats/display-page-1-toggle
```

Alternatively, you can use the default stats info command
```EditorConfig
# modernz.conf
info_mbtn_left_command=script-binding stats/display-stats-toggle
```

Fixes: https://github.com/Samillion/ModernZ/issues/351