### PR TITLE
refactor: bind right clicking the title to show history

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -219,8 +219,8 @@ Customize the button function based on mouse actions.
 | Type                          | Option                           | Function                                                                        |
 | ----------------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
 | Title (above seekbar)         | title_mbtn_left_command          | `script-binding stats/display-page-5`                                           |
-|                               | title_mbtn_mid_command           | `show-text ${filename}`                                                         |
-|                               | title_mbtn_right_command         | `show-text ${path}`                                                             |
+|                               | title_mbtn_mid_command           | `show-text ${path}`                                                             |
+|                               | title_mbtn_right_command         | `script-binding select/select-watch-history; script-message-to modernz osc-hide`|
 | Playlist Button               | playlist_mbtn_left_command       | `script-binding select/select-playlist; script-message-to modernz osc-hide`     |
 |                               | playlist_mbtn_right_command      | `show-text ${playlist} 3000`                                                    |
 | Volume Control                | vol_ctrl_mbtn_left_command       | `no-osd cycle mute`                                                             |

--- a/modernz.conf
+++ b/modernz.conf
@@ -321,8 +321,8 @@ osc_height=132
 
 # title above seekbar mouse actions
 title_mbtn_left_command=script-binding stats/display-page-5
-title_mbtn_mid_command=show-text ${filename}
-title_mbtn_right_command=show-text ${path}
+title_mbtn_mid_command=show-text ${path}
+title_mbtn_right_command=script-binding select/select-watch-history; script-message-to modernz osc-hide
 
 # playlist button mouse actions
 playlist_mbtn_left_command=script-binding select/select-playlist; script-message-to modernz osc-hide

--- a/modernz.lua
+++ b/modernz.lua
@@ -206,8 +206,8 @@ local user_opts = {
 
     -- title above seekbar mouse actions
     title_mbtn_left_command = "script-binding stats/display-page-5",
-    title_mbtn_mid_command = "show-text ${filename}",
-    title_mbtn_right_command = "show-text ${path}",
+    title_mbtn_mid_command = "show-text ${path}",
+    title_mbtn_right_command = "script-binding select/select-watch-history; script-message-to modernz osc-hide",
 
     -- playlist button mouse actions
     playlist_mbtn_left_command = "script-binding select/select-playlist; script-message-to modernz osc-hide",


### PR DESCRIPTION
Based on mpv 0.40 changes.

left-click = show file and track info
middle-click = show the path
right-click = open the history selector
