### PR TITLE
feat: add osc transparency options

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -119,35 +119,37 @@ Create `modernz.conf` in your mpv script-opts directory:
 
 ### Colors and style
 
-| Option                      | Value     | Description                                                                                       |
-| --------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
-| osc_color                   | `#000000` | accent color of the OSC and title bar                                                             |
-| window_title_color          | `#FFFFFF` | color of the title in borderless/fullscreen mode                                                  |
-| window_controls_color       | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode            |
-| windowcontrols_close_hover  | `#E81123` | color of close window control on hover                                                            |
-| windowcontrols_max_hover    | `#F8BC3A` | color of maximize window controls on hover                                                        |
-| windowcontrols_min_hover    | `#43CB44` | color of minimize window controls on hover                                                        |
-| title_color                 | `#FFFFFF` | color of the title (above seekbar)                                                                |
-| seekbarfg_color             | `#FB8C00` | color of the seekbar progress and handle                                                          |
-| seekbarbg_color             | `#94754F` | color of the remaining seekbar                                                                    |
-| seekbar_cache_color         | `#918F8E` | color of the cache ranges on the seekbar                                                          |
-| volumebar_match_seek_color  | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
-| time_color                  | `#FFFFFF` | color of the timestamps (below seekbar)                                                           |
-| chapter_title_color         | `#FFFFFF` | color of the chapter title (above seekbar)                                                        |
-| cache_info_color            | `#FFFFFF` | color of the cache information                                                                    |
-| side_buttons_color          | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                                      |
-| middle_buttons_color        | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                           |
-| playpause_color             | `#FFFFFF` | color of the play/pause button                                                                    |
-| held_element_color          | `#999999` | color of the element when held down (pressed)                                                     |
-| hover_effect_color          | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                  |
-| thumbnail_border_color      | `#111111` | color of the border for thumbnails (with thumbfast)                                               |
-| thumbnail_border_outline    | `#404040` | color of the border outline for thumbnails                                                        |
-| fade_alpha                  | 130       | alpha of the OSC background box (0 to disable)                                                    |
-| fade_blur_strength          | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render   |
-| window_fade_alpha           | 100       | alpha of the window title bar (0 to disable)                                                      |
-| window_fade_blur_strength   | 100       | blur strength for the window title bar. caution: high values can take a lot of CPU time to render |
-| thumbnail_border            | 3         | width of the thumbnail border (for thumbfast)                                                     |
-| thumbnail_border_radius     | 3         | rounded corner radius for thumbnail border (0 to disable)                                         |
+| Option                            | Value     | Description                                                                                       |
+| --------------------------------- | --------- | ------------------------------------------------------------------------------------------------- |
+| osc_color                         | `#000000` | accent color of the OSC and title bar                                                             |
+| window_title_color                | `#FFFFFF` | color of the title in borderless/fullscreen mode                                                  |
+| window_controls_color             | `#FFFFFF` | color of the window controls (close, minimize, maximize) in borderless/fullscreen mode            |
+| windowcontrols_close_hover        | `#E81123` | color of close window control on hover                                                            |
+| windowcontrols_max_hover          | `#F8BC3A` | color of maximize window controls on hover                                                        |
+| windowcontrols_min_hover          | `#43CB44` | color of minimize window controls on hover                                                        |
+| title_color                       | `#FFFFFF` | color of the title (above seekbar)                                                                |
+| seekbarfg_color                   | `#FB8C00` | color of the seekbar progress and handle                                                          |
+| seekbarbg_color                   | `#94754F` | color of the remaining seekbar                                                                    |
+| seekbar_cache_color               | `#918F8E` | color of the cache ranges on the seekbar                                                          |
+| volumebar_match_seek_color        | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
+| time_color                        | `#FFFFFF` | color of the timestamps (below seekbar)                                                           |
+| chapter_title_color               | `#FFFFFF` | color of the chapter title (above seekbar)                                                        |
+| cache_info_color                  | `#FFFFFF` | color of the cache information                                                                    |
+| side_buttons_color                | `#FFFFFF` | color of the side buttons (audio, subtitles, playlist, etc.)                                      |
+| middle_buttons_color              | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                           |
+| playpause_color                   | `#FFFFFF` | color of the play/pause button                                                                    |
+| held_element_color                | `#999999` | color of the element when held down (pressed)                                                     |
+| hover_effect_color                | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                  |
+| thumbnail_border_color            | `#111111` | color of the border for thumbnails (with thumbfast)                                               |
+| thumbnail_border_outline          | `#404040` | color of the border outline for thumbnails                                                        |
+| fade_alpha                        | 130       | alpha of the OSC background box (0 to disable)                                                    |
+| fade_blur_strength                | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render   |
+| fade_transparency_strength        | 0         | use with "fade_blur_strength=0" to create a transparency box                                      |
+| window_fade_alpha                 | 100       | alpha of the window title bar (0 to disable)                                                      |
+| window_fade_blur_strength         | 100       | blur strength for the window title bar. caution: high values can take a lot of CPU time to render |
+| window_fade_transparency_strength | 0         | use with "window_fade_blur_strength=0" to create a transparency box                               |
+| thumbnail_border                  | 3         | width of the thumbnail border (for thumbfast)                                                     |
+| thumbnail_border_radius           | 3         | rounded corner radius for thumbnail border (0 to disable)                                         |
 
 ### Button hover effects
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -221,10 +221,14 @@ thumbnail_border_outline=#404040
 fade_alpha=130
 # blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
 fade_blur_strength=100
+# use with "fade_blur_strength=0" to create a transparency box
+fade_transparency_strength=0
 # alpha of the window title bar (0 to disable)
 window_fade_alpha=100
 # blur strength for the window title bar. caution: high values can take a lot of CPU time to render
 window_fade_blur_strength=100
+# use with "window_fade_blur_strength=0" to create a transparency box
+window_fade_transparency_strength=0
 # width of the thumbnail border (for thumbfast)
 thumbnail_border=3
 # rounded corner radius for thumbnail border (0 to disable)

--- a/modernz.lua
+++ b/modernz.lua
@@ -146,8 +146,10 @@ local user_opts = {
 
     fade_alpha = 130,                      -- alpha of the OSC background (0 to disable)
     fade_blur_strength = 100,              -- blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
+    fade_transparency_strength = 0,        -- use with "fade_blur_strength=0" to create a transparency box
     window_fade_alpha = 100,               -- alpha of the window title bar (0 to disable)
     window_fade_blur_strength = 100,       -- blur strength for the window title bar. caution: high values can take a lot of CPU time to render
+    window_fade_transparency_strength = 0, -- use with "window_fade_blur_strength=0" to create a transparency box
     thumbnail_border = 3,                  -- width of the thumbnail border (for thumbfast)
     thumbnail_border_radius = 3,           -- rounded corner radius for thumbnail border (0 to disable)
 
@@ -1679,7 +1681,7 @@ layouts["modern"] = function ()
     lo.geometry = {x = posX, y = posY, an = 7, w = osc_w, h = 1}
     lo.style = osc_styles.osc_fade_bg
     lo.layer = 10
-    lo.alpha[3] = 0
+    lo.alpha[3] = user_opts.fade_transparency_strength
 
     local top_titlebar = window_controls_enabled() and (user_opts.window_title or user_opts.window_controls)
 
@@ -1690,7 +1692,7 @@ layouts["modern"] = function ()
         lo.geometry = {x = posX, y = -100, an = 7, w = osc_w, h = -1}
         lo.style = osc_styles.window_fade_bg
         lo.layer = 10
-        lo.alpha[3] = 0
+        lo.alpha[3] = user_opts.window_fade_transparency_strength
     end
 
     -- Alignment
@@ -1964,7 +1966,7 @@ layouts["modern-image"] = function ()
     lo.geometry = {x = posX, y = posY, an = 7, w = osc_w, h = 1}
     lo.style = osc_styles.osc_fade_bg
     lo.layer = 10
-    lo.alpha[3] = 0
+    lo.alpha[3] = user_opts.fade_transparency_strength
 
     local top_titlebar = window_controls_enabled() and (user_opts.window_title or user_opts.window_controls)
 
@@ -1975,7 +1977,7 @@ layouts["modern-image"] = function ()
         lo.geometry = {x = posX, y = -100, an = 7, w = osc_w, h = -1}
         lo.style = osc_styles.window_fade_bg
         lo.layer = 10
-        lo.alpha[3] = 0
+        lo.alpha[3] = user_opts.window_fade_transparency_strength
     end
 
     -- Alignment


### PR DESCRIPTION
Add two new options: 
- `fade_transparency_strength`
- `window_fade_transparency_strength`

This adds more customization to the fade options and can be used to create a transparency box for the top and bottom of the OSC.

Edit: Config settings example

**Botton box**
```EditorConfig
# alpha of the OSC background box 
# This sets the size of the box. The higher the number, the larger the box
fade_alpha=80
# blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render
# Set this to 0 to create the box
fade_blur_strength=0
# use with "fade_blur_strength=0" to create a transparency box
# This sets the amount of transparency
fade_transparency_strength=75
```

**Top box**
```EditorConfig
# alpha of the window title bar (0 to disable)
# This sets the size of the box. The higher the number, the larger the box
window_fade_alpha=152
# blur strength for the window title bar. caution: high values can take a lot of CPU time to render
# Set this to 0 to create the box
window_fade_blur_strength=0
# use with "window_fade_blur_strength=0" to create a transparency box
# This sets the amount of transparency
window_fade_transparency_strength=75
```
