### PR TITLE
fix: update playlist position on change

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3383,6 +3383,7 @@ end)
 mp.register_event("start-file", request_init)
 mp.observe_property("track-list", "native", request_init)
 mp.observe_property("playlist-count", "native", request_init)
+mp.observe_property("playlist-pos", "native", request_init)
 mp.observe_property("chapter-list", "native", function(_, list)
     list = list or {}  -- safety, shouldn't return nil
     table.sort(list, function(a, b) return a.time < b.time end)


### PR DESCRIPTION
> This ensures that the next/previous buttons are appropriately enabled/disabled when the position of the currently playing entry is changed.

Reference: https://github.com/mpv-player/mpv/pull/16244