### PR TITLE
fix: respect manual sub-pos by user during playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ ModernZ supports mpv's built-in console/select ([v0.40+](https://github.com/mpv-
    ```
    mpv/
    ├── fonts/
-   │   └── fluent-system-icons.ttf
+   │   ├── fluent-system-icons.ttf
+   │   └── material-design-icons.ttf
    ├── script-opts/
    │   └── modernz.conf
    └── scripts/


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/370

#### Changes
- Respect manual `sub-pos` by user during playback all while maintaining show/hide osc sub rise.
- Don't adjust subtitle position if user's `sub-pos` is higher (on screen) than the raise factor when osc is visible
- Simplify scale logic into a variable