### PR TITLE
pause-indicator: add mute indicator options

### DIFF
--- a/extras/pause-indicator-lite/README.md
+++ b/extras/pause-indicator-lite/README.md
@@ -2,7 +2,7 @@
 | ![pause-icon](https://github.com/user-attachments/assets/cd41333c-8fdd-4de9-8977-15eea95798dc) | ![play-icon](https://github.com/user-attachments/assets/0d1671f8-9b1b-4f10-ade3-82d1748b2d93) |
 |:---:|:---:|
 
-A simple script that displays an indicator on pause, with options to adjust icon type, color, height, width, opacity and whether to toggle pause with a keybind or not.
+A simple script that displays an indicator on pause (and mute), with options to adjust icon type, color, height, width, opacity and whether to toggle pause with a keybind or not.
 
 I only decided to write this because the ones I found were either too complicated or too simple. The alternatives are great, this one just meets my simple use case scenario.
 
@@ -36,7 +36,9 @@ To adjust them you can either:
 | `flash_play_icon`        | yes         | flash play icon on unpause (best with pause indicator icon)                                                                          |
 | `flash_icon_timeout`     | 0.3         | timeout (seconds) for flash icon                                                                                                     |
 | `fluent_icons`           | no          | requires `fonts/fluent-system-icons.ttf` [[details](https://github.com/Samillion/ModernZ/pull/336)]                                  |
-| `fluent_icon_size`       | 90          | fluent icon size                                                                                                                     |
+| `fluent_icon_size`       | 80          | fluent icon size                                                                                                                     |
+| `mute_indicator`         | no          | show a mute indicator (requires fluent font)                                                                                         |
+| `mute_indicator_pos`     | middle_left | position of mute indicator. `top_left`, `top_right`, `top_center`. also: `middle_*`, `bottom_*` same as `top_*` (ie: `bottom_right`) |
 
 ### How to install
 

--- a/extras/pause-indicator-lite/README.md
+++ b/extras/pause-indicator-lite/README.md
@@ -38,7 +38,7 @@ To adjust them you can either:
 | `fluent_icons`           | no          | requires `fonts/fluent-system-icons.ttf` [[details](https://github.com/Samillion/ModernZ/pull/336)]                                  |
 | `fluent_icon_size`       | 80          | fluent icon size                                                                                                                     |
 | `mute_indicator`         | no          | show a mute indicator (requires fluent font)                                                                                         |
-| `mute_indicator_pos`     | middle_left | position of mute indicator. `top_left`, `top_right`, `top_center`. also: `middle_*`, `bottom_*` same as `top_*` (ie: `bottom_right`) |
+| `mute_indicator_pos`     | middle_right | position of mute indicator. `top_left`, `top_right`, `top_center`. also: `middle_*`, `bottom_*` same as `top_*` (ie: `bottom_right`) |
 
 ### How to install
 

--- a/extras/pause-indicator-lite/pause_indicator_lite.conf
+++ b/extras/pause-indicator-lite/pause_indicator_lite.conf
@@ -51,4 +51,4 @@ fluent_icon_size=80
 mute_indicator=no
 # position of mute indicator. top_left, top_right, top_center
 # also: middle_*, bottom_* same as top_* (ie: bottom_right)
-mute_indicator_pos=middle_left
+mute_indicator_pos=middle_right

--- a/extras/pause-indicator-lite/pause_indicator_lite.conf
+++ b/extras/pause-indicator-lite/pause_indicator_lite.conf
@@ -44,4 +44,11 @@ flash_icon_timeout=0.3
 # requires fonts/fluent-system-icons.ttf
 fluent_icons=no
 # fluent icon size
-fluent_icon_size=90
+fluent_icon_size=80
+
+# mute options
+# show a mute indicator (requires fluent font)
+mute_indicator=no
+# position of mute indicator. top_left, top_right, top_center
+# also: middle_*, bottom_* same as top_* (ie: bottom_right)
+mute_indicator_pos=middle_left

--- a/extras/pause-indicator-lite/pause_indicator_lite.lua
+++ b/extras/pause-indicator-lite/pause_indicator_lite.lua
@@ -7,38 +7,43 @@
 
 local options = {
     -- indicator icon type
-    indicator_icon = "pause",        -- indicator icon type. "pause", "play"
-    indicator_stay = true,           -- keep indicator visibile during pause
-    indicator_timeout = 0.6,         -- timeout (seconds) if indicator doesn't stay
+    indicator_icon = "pause",             -- indicator icon type. "pause", "play"
+    indicator_stay = true,                -- keep indicator visibile during pause
+    indicator_timeout = 0.6,              -- timeout (seconds) if indicator doesn't stay
 
     -- keybind
-    keybind_allow = true,            -- allow keybind to toggle pause
-    keybind_set = "mbtn_left",       -- the used keybind to toggle pause
-    keybind_mode = "onpause",        -- mode to activate keybind. "onpause", "always"
-    keybind_eof_disable = true,      -- disable keybind on eof (end of file)
+    keybind_allow = true,                 -- allow keybind to toggle pause
+    keybind_set = "mbtn_left",            -- the used keybind to toggle pause
+    keybind_mode = "onpause",             -- mode to activate keybind. "onpause", "always"
+    keybind_eof_disable = true,           -- disable keybind on eof (end of file)
 
     -- icon colors & opacity
-    icon_color = "#FFFFFF",          -- icon fill color
-    icon_border_color = "#111111",   -- icon border color
-    icon_border_width = 1.5,         -- icon border width
-    icon_opacity = 40,               -- icon opacity (0-100)
+    icon_color = "#FFFFFF",               -- icon fill color
+    icon_border_color = "#111111",        -- icon border color
+    icon_border_width = 1.5,              -- icon border width
+    icon_opacity = 40,                    -- icon opacity (0-100)
 
     -- pause icon
-    rectangles_width = 30,           -- width of rectangles
-    rectangles_height = 80,          -- height of rectangles
-    rectangles_spacing = 20,         -- spacing between the two rectangles
+    rectangles_width = 30,                -- width of rectangles
+    rectangles_height = 80,               -- height of rectangles
+    rectangles_spacing = 20,              -- spacing between the two rectangles
 
     -- play icon
-    triangle_width = 80,             -- width of triangle
-    triangle_height = 80,            -- height of triangle
+    triangle_width = 80,                  -- width of triangle
+    triangle_height = 80,                 -- height of triangle
 
     -- best with pause icon
-    flash_play_icon = true,          -- flash play icon on unpause
-    flash_icon_timeout = 0.3,        -- timeout (seconds) for flash icon
+    flash_play_icon = true,               -- flash play icon on unpause
+    flash_icon_timeout = 0.3,             -- timeout (seconds) for flash icon
 
     -- icon style used in ModernZ osc
-    fluent_icons = false,            -- requires fonts/fluent-system-icons.ttf
-    fluent_icon_size = 90,           -- fluent icon size
+    fluent_icons = false,                 -- requires fonts/fluent-system-icons.ttf
+    fluent_icon_size = 80,                -- fluent icon size
+    
+    -- mute options
+    mute_indicator = false,               -- show a mute indicator (requires fluent font)
+    mute_indicator_pos = "middle_right",  -- position of mute indicator. top_left, top_right, top_center
+                                          -- also: middle_*, bottom_* same as top_* (ie: bottom_right)
 }
 
 local msg = require "mp.msg"
@@ -92,9 +97,31 @@ local function draw_triangle()
     end
 end
 
+-- mute icon
+local function draw_mute()
+    if not options.fluent_icons then return end
+
+    local mute_icon = "\238\173\138"
+    local mute_pos_list = {
+        ["top_left"] = 7,
+        ["top_center"] = 8,
+        ["top_right"] = 9,
+        ["middle_left"] = 4,
+        ["middle_center"] = 5,
+        ["middle_right"] = 6,
+        ["bottom_left"] = 1,
+        ["bottom_center"] = 2,
+        ["bottom_right"] = 3,
+    }
+    local mute_pos = mute_pos_list[options.mute_indicator_pos:lower()] or 6
+    return string.format([[{\\rDefault\\an%s\\alpha&H%s\\bord%s\\1c&H%s&\\3c&H%s&\\fs%s\\fn%s}%s]],
+        mute_pos, icon_opacity, options.icon_border_width, icon_color, icon_border_color, options.fluent_icon_size, icon_font, mute_icon)
+end
+
 -- initiate overlay
 local indicator = mp.create_osd_overlay("ass-events")
 local flash = mp.create_osd_overlay("ass-events")
+local mute = mp.create_osd_overlay("ass-events")
 
 -- keep track of pause toggle and end of file
 local toggled, eof
@@ -118,6 +145,12 @@ local function flash_icon()
     flash.data = draw_triangle()
     flash:update()
     mp.add_timeout(options.flash_icon_timeout, function() flash:remove() end)
+end
+
+-- draw mute icon
+local function mute_icon()
+    mute.data = draw_mute()
+    mute:update()
 end
 
 -- check if file is video
@@ -175,3 +208,11 @@ mp.observe_property("osd-dimensions", "native", function()
         update_indicator()
     end
 end)
+
+if options.mute_indicator and options.fluent_icons then
+    mp.observe_property("mute", "bool", function(_, val)
+        if val and not mute.visible then mute_icon() else mute:remove() end
+    end)
+else
+    mute:remove()
+end


### PR DESCRIPTION
### Feature
Add options to show an indicator on mute and control position of mute indicator

### Options
- `mute_indicator`
- `mute_indicator_pos`

### Usage
Adjust the following options in `pause_indicator_lite.conf`
```EditorConfig
# mute options
# show a mute indicator (requires fluent font)
mute_indicator=no
# position of mute indicator. top_left, top_right, top_center
# also: middle_*, bottom_* same as top_* (ie: bottom_right)
mute_indicator_pos=middle_left
```

### Preview
![image](https://github.com/user-attachments/assets/ba49ba53-f6c0-4833-9c86-5a39ef2ce569)

Fixes: https://github.com/Samillion/ModernZ/issues/361
