### PR TITLE
refactor: make rendering smoother

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -200,7 +200,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | ----------------------------- | ----------------- | ------------------------------------------------------------- |
 | visibility                    | auto              | only used at init to set visibility_mode(...)                 |
 | visibility_modes              | never_auto_always | visibility modes to cycle through, modes are separated by `_` |
-| tick_delay                    | 0.03              | minimum interval between OSC redraws (in seconds)             |
+| tick_delay                    | 1 / 60            | minimum interval between OSC redraws (in seconds)             |
 | tick_delay_follow_display_fps | no                | use display FPS as the minimum redraw interval                |
 
 ### Elements Position

--- a/modernz.conf
+++ b/modernz.conf
@@ -305,7 +305,7 @@ visibility=auto
 # visibility modes to cycle through, modes are separated by _
 visibility_modes=never_auto_always
 # minimum interval between OSC redraws (in seconds)
-tick_delay=0.03
+tick_delay=1 / 60
 # use display FPS as the minimum redraw interval
 tick_delay_follow_display_fps=no
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -192,7 +192,7 @@ local user_opts = {
     -- Miscellaneous settings
     visibility = "auto",                   -- only used at init to set visibility_mode(...)
     visibility_modes = "never_auto_always",-- visibility modes to cycle through
-    tick_delay = 0.03,                     -- minimum interval between OSC redraws (in seconds)
+    tick_delay = 1 / 60,                   -- minimum interval between OSC redraws (in seconds)
     tick_delay_follow_display_fps = false, -- use display FPS as the minimum redraw interval
 
     -- Elements Position


### PR DESCRIPTION
Upstream fix from mpv. Changes default tick_delay to 1 / 60 to improve rendering performance.

References:
- https://github.com/mpv-player/mpv/commit/6337bc27ffb4d89b0c2a4a97c712e2b97a05bcd4
- https://github.com/maoiscat/mpv-osc-modern/issues/57
