### PR TITLE
fix: prevent osc crash with initiated nil values

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -554,8 +554,8 @@ end
 
 -- internal states, do not touch
 local state = {
-    showtime = nil,                         -- time of last invocation (last mouse move)
-    touchtime = nil,                        -- time of last invocation (last touch event)
+    showtime = mp.get_time(),               -- time of last invocation (last mouse move)
+    touchtime = mp.get_time(),              -- time of last invocation (last touch event)
     touchpoints = {},                       -- current touch points
     osc_visible = false,
     anistart = nil,                         -- time when the animation started


### PR DESCRIPTION
**Fixes**: #460 

**Changes**:
- Initiate `state.showtime` and `state.touchtime` with `mp.get_time()`
  - Prevents `nil` values on `mouse_leave()` and `process_event(source, what)` calls
- Other events and inputs are not affected, as `mp.get_time()` is recalled correctly when needed to re-populate with the latest time value

**Reason**: https://github.com/Samillion/ModernZ/issues/460#issuecomment-3940157957