### PR TITLE
refactor: show playlist position and count as tooltip for playlist button

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -2778,7 +2778,7 @@ local function osc_init()
     ne.visible = (osc_param.playresx >= (state.is_image and 250 or visible_min_width) - outeroffset)
     ne.content = icons.playlist
     ne.tooltip_style = osc_styles.tooltip
-    ne.tooltipF = user_opts.tooltip_hints and locale.playlist .. "/" .. locale.menu or ""
+    ne.tooltipF = have_pl and locale.playlist .. " [" .. pl_pos .. "/" .. pl_count .. "]" or locale.playlist .. " / " .. locale.menu
     ne.nothingavailable = locale.no_playlist
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.playlist_mbtn_left_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.playlist_mbtn_right_command)


### PR DESCRIPTION
- Multi entry playlist will show: `Playlist [1/8]`
  - `1` being the current position in the playlist, `8` being the total entries
- Single file will show `Playlist / Menu`
- `Playlist` and `Menu` phrases follow the used language (locale)