### PR TITLE
refactor: reduce redundancy for hidetimeout

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3624,9 +3624,9 @@ local function process_event(source, what)
                         if in_top then show_wc() end
                     elseif in_bottom or in_top then
                         show_osc()
-                else
-                    state.touchtime = nil
-                end
+                    else
+                        state.touchtime = nil
+                    end
                 else
                     show_osc()
                     if user_opts.independent_wc then


### PR DESCRIPTION
I am not sure what I was doing there at the time or why I repeated this code so many times needlessly.

**Changes**:
- Let the actual helpers handle hidetimeout instead of repeating it multiple times.

@Keith94 One example of repeated code and redundancy like I mentioned earlier. My initial tests shows everything working as it should.

But, knowing that my brain only pretends to exist, please let me know if I broke more things than fixed lol.