### PR TITLE
fix: correctly apply top bar margins when visible

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1846,6 +1846,8 @@ local function window_controls()
 
         add_area("window-controls-title", titlebox_left, 0, titlebox_right, wc_geo.h)
     end
+    -- top bar margins
+    osc_param.video_margins.t = wc_geo.h / osc_param.playresy
 end
 
 --
@@ -2669,6 +2671,9 @@ local function osc_init()
 
     -- stop seeking with the slider to prevent skipping files
     state.active_element = nil
+
+    -- reset margins
+    osc_param.video_margins = {l = 0, r = 0, t = 0, b = 0}
 
     elements = {}
 


### PR DESCRIPTION
For some reason I never assigned margins for top bar.

**Changes**:
- Apply top bar margins when it's visible

**After fix**:
<img width="1227" height="692" alt="top_margins_after" src="https://github.com/user-attachments/assets/e5ff09ec-466b-4e85-b543-057037eb5939" />

**Before fix**:
<img width="1227" height="692" alt="top_margins_before" src="https://github.com/user-attachments/assets/682dadf4-175c-482c-a618-fef2446d1c5d" />
