### PR TITLE
fix: don't use goto due to compatibility

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1294,13 +1294,13 @@ local function render_elements(master_ass, osc_vis, wc_vis)
 
     state.touchingprogressbar = false
 
-    for n=1, #elements do repeat
+    local function render_element(n)
         local element = elements[n]
 
         -- skip elements whose group is not currently visible
         local is_top = element.layout.group == "top"
         if (is_top and not wc_vis) or (not is_top and not osc_vis) then
-            break
+            return
         end
 
         -- use wc animation for top group in independent mode
@@ -1580,7 +1580,11 @@ local function render_elements(master_ass, osc_vis, wc_vis)
         end
 
         master_ass:merge(elem_ass)
-    until true end
+    end
+
+    for n = 1, #elements do
+        render_element(n)
+    end
 end
 
 local function render_persistentprogressbar(master_ass)


### PR DESCRIPTION
The main reason is that `goto` has been added in `lua 5.2`.

Originated from this comment on irc:
```
<guido> why is there a goto to render_elements()
<guido> kasper93: that doesn't work in lua 5.1
```
While mpv supports lua 5.1 and 5.2, in the end it all depends on how the package was built.

Followup: https://github.com/mpv-player/mpv/pull/17512