### PR TITLE
refactor: remove seek_resets_hidetimeout option

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -32,7 +32,6 @@ Create `modernz.conf` in your mpv script-opts directory:
 | Option                  | Value | Description                                                                      |
 | ----------------------- | ----- | -------------------------------------------------------------------------------- |
 | hidetimeout             | 2000  | time (in ms) before OSC hides if no mouse movement                               |
-| seek_resets_hidetimeout | yes   | if seeking should reset the hidetimeout                                          |
 | fadeduration            | 200   | fade-out duration (in ms), set to `"0"` for no fade                              |
 | fadein                  | no    | whether to enable fade-in effect                                                 |
 | minmousemove            | 0     | minimum mouse movement (in pixels) required to show OSC                          |

--- a/modernz.conf
+++ b/modernz.conf
@@ -28,8 +28,6 @@ greenandgrumpy=no
 # OSC behaviour and scaling
 # time (in ms) before OSC hides if no mouse movement
 hidetimeout=1500
-# if seeking should reset the hidetimeout
-seek_resets_hidetimeout=yes
 # fade-out duration (in ms), set to 0 for no fade
 fadeduration=200
 # whether to enable fade-in effect

--- a/modernz.lua
+++ b/modernz.lua
@@ -35,7 +35,6 @@ local user_opts = {
 
     -- OSC behaviour and scaling
     hidetimeout = 1500,                    -- time (in ms) before OSC hides if no mouse movement
-    seek_resets_hidetimeout = true,        -- if seeking should reset the hidetimeout
     fadeduration = 200,                    -- fade-out duration (in ms), set to 0 for no fade
     fadein = false,                        -- whether to enable fade-in effect
     minmousemove = 0,                      -- minimum mouse movement (in pixels) required to show OSC
@@ -3914,7 +3913,7 @@ mp.register_event("seek", function()
     end
 end)
 mp.observe_property("seeking", "native", function(_, seeking)
-    if user_opts.seek_resets_hidetimeout then
+    if user_opts.osc_on_seek then
         reset_timeout()
     end
 end)


### PR DESCRIPTION
Makes it so `reset_timeout()` depends on `osc_on_seek` instead of `seek_resets_hidetimeout`. It seems more intuitive that timeout always resets if user wants to see osc when seeking.