### PR TITLE
feat: add indication of muted state to volume tooltips

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -374,7 +374,7 @@ local language = {
         subtitle = "Subtitle",
         no_subs = "No subtitles available",
         no_audio = "No audio tracks available",
-        muted = " (Muted)",
+        muted = "Muted",
         playlist = "Playlist",
         no_playlist = "Playlist is empty",
         chapter = "Chapter",
@@ -2863,7 +2863,7 @@ local function osc_init()
         local volume = mp.get_property_number("volume", 0) or 0
         -- show only one decimal, if decimals exist
         volume = volume % 1 == 0 and string.format("%.0f", volume) or string.format("%.1f", volume)
-        return state.mute and (volume .. locale.muted) or volume
+        return state.mute and (volume .. " (" .. locale.muted .. ")") or volume
     end
     ne.eventresponder["mbtn_left_up"] = command_callback(user_opts.vol_ctrl_mbtn_left_command)
     ne.eventresponder["mbtn_right_up"] = command_callback(user_opts.vol_ctrl_mbtn_right_command)
@@ -2889,7 +2889,7 @@ local function osc_init()
     ne.slider.tooltipF = function(pos)
         if audio_track_count <= 0 then return end
         local volume = set_volume(pos)
-        return state.mute and (volume .. locale.muted) or volume
+        return state.mute and (volume .. " (" .. locale.muted .. ")") or volume
     end
 
     ne.eventresponder["mouse_move"] = function (element)


### PR DESCRIPTION
- Change volume button tooltip to "Mute/Unmute" to show what it does (English only)
- Append (Muted) to volume bar tooltip if audio is muted.