### PR TITLE
fix: improve playing_and_seeking state use to avoid race on drag

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3202,14 +3202,22 @@ local function osc_init()
     end
     ne.eventresponder["mbtn_left_down"] = function (element)
         element.state.mbtnleft = true
+        state.playing_and_seeking = false  -- clear state
         mp.commandv("seek", get_slider_value(element), "absolute-percent+exact")
     end
     ne.eventresponder["shift+mbtn_left_down"] = function (element)
         element.state.mbtnleft = true
+        state.playing_and_seeking = false
         mp.commandv("seek", get_slider_value(element), "absolute-percent")
     end
     ne.eventresponder["mbtn_left_up"] = function (element)
         element.state.mbtnleft = false
+        if state.playing_and_seeking then
+            if mp.get_property("eof-reached") == "no" and user_opts.mouse_seek_pause then
+                mp.commandv("cycle", "pause")
+            end
+            state.playing_and_seeking = false
+        end
     end
     ne.eventresponder["mbtn_right_down"] = function (element)
         local chapter
@@ -3229,12 +3237,6 @@ local function osc_init()
     end
     ne.eventresponder["reset"] = function (element)
         element.state.lastseek = nil
-        if state.playing_and_seeking then
-            if mp.get_property("eof-reached") == "no" and user_opts.mouse_seek_pause then
-                mp.commandv("cycle", "pause")
-            end
-            state.playing_and_seeking = false
-        end
     end
     ne.eventresponder["wheel_up_press"] = function () mp.commandv("seek", 10) end
     ne.eventresponder["wheel_down_press"] = function () mp.commandv("seek", -10) end


### PR DESCRIPTION
**Fixes**: https://github.com/Samillion/ModernZ/pull/496#issuecomment-4016080054

**Changes**:
- Clear `playing_and_seeking` state in `mbtn_left_down` events on seekbar slider
- Move `mouse_seek_pause` branch to `mbtn_left_up` instead of `reset` event responder
  - `reset` event responder triggers on any `up` event, which could cause an early unpause

This avoids any stuck state which could cause erratic behavior on multiple button presses (up + down, right + left). I hope lol.

@Keith94