### PR TITLE
refactor: remove redundant checks in hover zones

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3461,9 +3461,8 @@ local function process_event(source, what)
                 end
                 if user_opts.bottomhover then -- if enabled, only show osc if mouse is hovering at the bottom of the screen (where the UI elements are)
                     local top_hover = window_controls_enabled() and (user_opts.show_window_title or user_opts.window_controls)
-                    local in_bottom = mouseY > osc_param.playresy - (user_opts.bottomhover_zone or 130)
-                    local in_top = ((user_opts.window_top_bar == "yes" or not (state.border and state.title_bar)) or state.fullscreen)
-                        and (mouseY < user_opts.tophover_zone and top_hover)
+                    local in_bottom = mouseY > osc_param.playresy - user_opts.bottomhover_zone
+                    local in_top = mouseY < user_opts.tophover_zone and top_hover
 
                     if user_opts.independent_zones then
                         if in_bottom then show_osc() end


### PR DESCRIPTION
**Changes**:
- `local in_bottom` had a redundant check `or 130`, which could cause a false result
  - It is already set in `bottomhover_zone` defaults
  - If user sets `bottomhover_zone` to `0`, it would be changed to `130`, because `0` is `falsy`
- `local in_top` had checks that are already set in `local top_hover`
