### PR TITLE
fix: don't let input events reset window controls bar hidetimeout

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3649,7 +3649,9 @@ local function render()
         if state.pause_osc_locked and showtime_key == "showtime" then return end
         local timeout = state[showtime_key] + (hide_timeout / 1000) - now
         if timeout <= 0 and get_touchtimeout() <= 0 then
-            if state.active_element == nil and (not mouse_in_area(input_areas) or not user_opts.osc_keep_with_cursor) then
+            -- area elements should affect the specific area only. (ie: seekbar drag shouldn't affect top bar)
+            local element_blocks_hide = state.active_element ~= nil and mouse_in_area(input_areas)
+            if not element_blocks_hide and (not mouse_in_area(input_areas) or not user_opts.osc_keep_with_cursor) then
                 hide_fn()
             end
         else


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/pull/523#issuecomment-4035396194 reported by @Keith94, ModernZ's local detective. 

**Changes**:
- Top bar (WC bar) `hidetimeout` should reset only if mouse is hovering it.
  - It shouldn't be affected by input events that reset `hidetimeout` on the OSC with `reset_timeout()`.
- Area elements should only affect the specific area. (ie: seek drag should not reset timeout for top bar)
