### PR TITLE
refactor: show .0 for whole number playback speeds

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3088,8 +3088,8 @@ local function osc_init()
     --tog_speed
     ne = new_element("tog_speed", "button")
     ne.content = function()
-    local speed = mp.get_property_number("speed", 1)
-        return (speed % 1 == 0) and string.format("%.1f×", speed) or string.format("%g×", speed)
+        local speed = mp.get_property_number("speed", 1)
+        return string.format(speed % 1 == 0 and "%.1f×" or "%g×", speed)
     end
     ne.visible = (osc_param.playresx >= visible_min_width)
     ne.tooltip_style = osc_styles.tooltip


### PR DESCRIPTION
For example, 1× => 1.0× to keep it consistent with fractional speeds.