### PR TITLE
refactor: unify time codes width between layouts and cache rtl flag

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -452,10 +452,12 @@ if external then
 end
 
 local locale
-local rtl = false                           -- locale language direction (true if RTL)
+local rtl = false                  -- locale language direction (true if RTL)
+local rtl_reset = "{\\rDefault}"   -- cached ASS reset tag, includes \\fe-1 for RTL
 local function set_osc_locale()
     locale = language[user_opts.language] or language["en"]
     rtl = (locale.lang_direction or "ltr"):lower() == "rtl"
+    rtl_reset = rtl and "{\\rDefault\\fe-1}" or "{\\rDefault}"
 end
 
 local function contains(list, item)
@@ -730,6 +732,18 @@ local function estimate_text_width(text, style)
 
     text_width_cache[cache_key] = width
     return width
+end
+
+-- width of the time codes element
+local function get_time_codes_width(show_hours, show_remhours)
+    local t_fmt  = (show_hours and "00:00:00" or "00:00") .. (state.tc_ms and ".000" or "")
+    local rt_fmt = (show_remhours and "00:00:00" or "00:00") .. (state.tc_ms and ".000" or "")
+    local prefix = state.tc_left_rem and (user_opts.unicodeminus and UNICODE_MINUS or "-") or ""
+    local w = estimate_text_width(prefix .. rt_fmt .. " / " .. t_fmt, osc_styles.time)
+    if w == 0 then
+        w = 80 + (state.tc_ms and 50 or 0) + (state.tc_left_rem and 15 or 0) + (show_hours and 20 or 0) + (show_remhours and 20 or 0)
+    end
+    return w
 end
 
 -- returns hitbox spanning coordinates (top left, bottom right corner)
@@ -1616,7 +1630,7 @@ local function render_elements(master_ass, osc_vis, wc_vis)
                     end
 
                     elem_ass:new_event()
-                    elem_ass:append("{\\rDefault" .. (rtl and "\\fe-1" or "") .. "}")
+                    elem_ass:append(rtl_reset)
                     elem_ass:pos(tx, ty)
                     elem_ass:an(an)
                     elem_ass:append(element.tooltip_style)
@@ -2142,11 +2156,7 @@ layouts["modern"] = function ()
         - (auto_hide_volbar and 67 or 0) -- window width with audio track and elements
         - (audio_track and not user_opts.volume_control and 115 or 0) -- audio track with no elements
         - (not audio_track and 12 or 0) -- remove extra padding
-    local time_codes_width = 80
-        + (state.tc_ms and 50 or 0)
-        + (state.tc_left_rem and 15 or 0)
-        + (show_hours and 20 or 0)
-        + (show_remhours and 20 or 0)
+    local time_codes_width = get_time_codes_width(show_hours, show_remhours)
     local narrow_win = osc_param.playresx < (
         user_opts.portrait_window_trigger
         - outeroffset
@@ -2304,9 +2314,7 @@ layouts["modern-compact"] = function ()
     local dur = mp.get_property_number("duration", 0)
     local show_hours = mp.get_property_number("playback-time", 0) >= 3600 or user_opts.time_format ~= "dynamic"
     local show_remhours = (state.tc_left_rem and remsec >= 3600) or (not state.tc_left_rem and dur >= 3600) or user_opts.time_format ~= "dynamic"
-    local time_codes_width =
-        80 + (state.tc_ms and 50 or 0) + (state.tc_left_rem and 15 or 0) + (show_hours and 20 or 0) +
-        (show_remhours and 20 or 0)
+    local time_codes_width = get_time_codes_width(show_hours, show_remhours)
 
     -- OSC title
     local title_w = (chapter_index and (osc_geo.w - 50) or (osc_geo.w - 50 - time_codes_width))
@@ -2641,7 +2649,6 @@ local function format_time(seconds)
     end
 end
 
--- build cache seek ranges from state
 local function build_cache_seek_ranges()
     if not user_opts.seekrange or not cache_enabled() then return nil end
     local duration = mp.get_property_number("duration")


### PR DESCRIPTION
**Changes**:
- Cache RTL encoding tag instead of assigning it once per frame
- Unify time codes width using `get_time_codes_width()` which calls `estimate_text_width()` with preset formats
  - Time codes width hover/hitbox is still not perfect, but at least it's unified now