### PR TITLE
feat: make the volume unmute on volume changes

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -114,7 +114,7 @@ So, to control the raise amount of subtitles, adjust your `osc_height` and `osc_
 | track_nextprev_buttons     | yes           | show next/previous playlist track buttons                                                                          |
 | volume_control             | yes           | show mute button and volume slider                                                                                 |
 | volume_control_type        | linear        | volume scale type: `"linear"` or `"logarithmic"`                                                                   |
-| volumebar_unmute_on_click  | yes           | unmute audio when adjusting volume slider with left click                                                          |
+| volumebar_unmute_on_click  | no            | unmute audio when adjusting volume slider with left click                                                          |
 | playlist_button            | yes           | show playlist button: Left-click for simple playlist, Right-click for interactive playlist                         |
 | hide_empty_playlist_button | no            | hide playlist button when no playlist exists                                                                       |
 | gray_empty_playlist_button | no            | gray out the playlist button when no playlist exists                                                               |
@@ -243,10 +243,10 @@ Customize the button function based on mouse actions.
 |                               | playlist_mbtn_right_command      | `script-binding select/menu`                 |
 | Volume button                 | vol_ctrl_mbtn_left_command       | `no-osd cycle mute`                          |
 |                               | vol_ctrl_mbtn_right_command      | `script-binding select/select-audio-device`  |
-|                               | vol_ctrl_wheel_down_command      | `no-osd set mute no; no-osd add volume -5`   |
-|                               | vol_ctrl_wheel_up_command        | `no-osd set mute no; no-osd add volume 5`    |
-| Volume bar                    | volumebar_wheel_down_command     | `no-osd set mute no; osd-msg add volume -5`  |
-|                               | volumebar_wheel_up_command       | `no-osd set mute no; osd-msg add volume 5`   |
+|                               | vol_ctrl_wheel_down_command      | `osd-msg add volume -5`                      |
+|                               | vol_ctrl_wheel_up_command        | `osd-msg add volume 5`                       |
+| Volume bar                    | volumebar_wheel_down_command     | `osd-msg add volume -5`                      |
+|                               | volumebar_wheel_up_command       | `osd-msg add volume 5`                       |
 | Audio button                  | audio_track_mbtn_left_command    | `script-binding select/select-aid`           |
 |                               | audio_track_mbtn_mid_command     | `cycle audio down`                           |
 |                               | audio_track_mbtn_right_command   | `cycle audio`                                |

--- a/modernz.conf
+++ b/modernz.conf
@@ -149,7 +149,7 @@ volume_control=yes
 # volume scale type: "linear" or "logarithmic"
 volume_control_type=linear
 # unmute audio when adjusting volume slider with left click
-volumebar_unmute_on_click=yes
+volumebar_unmute_on_click=no
 # show playlist button
 playlist_button=yes
 # hide playlist button when no playlist exists
@@ -359,15 +359,13 @@ title_mbtn_right_command=script-binding select/select-watch-history
 playlist_mbtn_left_command=script-binding select/select-playlist
 playlist_mbtn_right_command=script-binding select/menu
 
-# volume button mouse actions
+# volume mouse actions
 vol_ctrl_mbtn_left_command=no-osd cycle mute
 vol_ctrl_mbtn_right_command=script-binding select/select-audio-device
-vol_ctrl_wheel_down_command=no-osd set mute no; no-osd add volume -5
-vol_ctrl_wheel_up_command=no-osd set mute no; no-osd add volume 5
-
-# volume bar mouse actions
-volumebar_wheel_down_command=no-osd set mute no; osd-msg add volume -5
-volumebar_wheel_up_command=no-osd set mute no; osd-msg add volume 5
+vol_ctrl_wheel_down_command=osd-msg add volume -5
+vol_ctrl_wheel_up_command=osd-msg add volume 5
+volumebar_wheel_down_command=osd-msg add volume -5
+volumebar_wheel_up_command=osd-msg add volume 5
 
 # audio button mouse actions
 audio_track_mbtn_left_command=script-binding select/select-aid

--- a/modernz.lua
+++ b/modernz.lua
@@ -101,7 +101,7 @@ local user_opts = {
 
     volume_control = true,                 -- show mute button and volume slider
     volume_control_type = "linear",        -- volume scale type: "linear" or "logarithmic"
-    volumebar_unmute_on_click = true,      -- unmute audio when adjusting volume slider with left click
+    volumebar_unmute_on_click = false,     -- unmute audio when adjusting volume slider with left click
     playlist_button = true,                -- show playlist button
     hide_empty_playlist_button = false,    -- hide playlist button when no playlist exists
     gray_empty_playlist_button = false,    -- gray out the playlist button when no playlist exists
@@ -227,10 +227,10 @@ local user_opts = {
     -- volume mouse actions
     vol_ctrl_mbtn_left_command = "no-osd cycle mute",
     vol_ctrl_mbtn_right_command = "script-binding select/select-audio-device",
-    vol_ctrl_wheel_down_command = "no-osd set mute no; no-osd add volume -5",
-    vol_ctrl_wheel_up_command = "no-osd set mute no; no-osd add volume 5",
-    volumebar_wheel_down_command = "no-osd set mute no; osd-msg add volume -5",
-    volumebar_wheel_up_command = "no-osd set mute no; osd-msg add volume 5",
+    vol_ctrl_wheel_down_command = "osd-msg add volume -5",
+    vol_ctrl_wheel_up_command = "osd-msg add volume 5",
+    volumebar_wheel_down_command = "osd-msg add volume -5",
+    volumebar_wheel_up_command = "osd-msg add volume 5",
 
     -- audio button mouse actions
     audio_track_mbtn_left_command = "script-binding select/select-aid",


### PR DESCRIPTION
When changing volume with OSC, unmute the audio if it was previously muted. It mimics the behavior of YouTube and Windows volume sliders.

EDIT: If you want it to also affect the mouse wheel, add this to `modernz.conf`:

```editorconfig
vol_ctrl_wheel_down_command=no-osd set mute no; osd-msg add volume -5
vol_ctrl_wheel_up_command=no-osd set mute no; osd-msg add volume 5
volumebar_wheel_down_command=no-osd set mute no; osd-msg add volume -5
volumebar_wheel_up_command=no-osd set mute no; osd-msg add volume 5
```