### PR TITLE
refactor: use observe_cached() for more properties

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3947,12 +3947,11 @@ local function idlescreen_visibility(mode, no_osd)
     request_tick()
 end
 
-mp.observe_property("pause", "bool", function(_, enabled)
-    state.pause = (enabled == true)
+observe_cached("pause", function()
     request_tick()
     if user_opts.showonpause and user_opts.visibility ~= "never" then
-        state.enabled = enabled
-        if enabled then
+        state.enabled = state.pause
+        if state.pause then
             if user_opts.keeponpause then
                 if user_opts.zones_hover_mode == "independent" then
                     show_osc()


### PR DESCRIPTION
**Changes**:
- Add `pause`, `eof_reached`, `volume`, `ontop` and `speed` states
- Use `observe_cached()` for relevant properties
- Replace property calls with state checks

This covers all properties that should be used by `observe_cached()` and to use state checks instead of direct property calls.

The whole idea is to optimize (well, micro-optimize) the efficiency per property call, per frame. It's not a significant improvement (most likely in unnoticeable milliseconds), but an improvement nevertheless.