### PR TITLE
fix: warn user if watch later options conflict is found

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -4068,7 +4068,7 @@ local function validate_user_opts()
         user_opts.showonpause = true
     end
 
-    local watch_later = "," .. (mp.get_property("options/watch-later-options") or "") .. ","
+    local watch_later = "," .. ((mp.get_property("options/watch-later-options") or ""):gsub("%s+", "")) .. ","
     if user_opts.sub_margins and watch_later:find(",sub-pos,", 1, true) then
         msg.warn("sub_margins: add watch-later-options-remove=sub-pos to mpv.conf")
     end


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/389

**Changes**:
- Warn user if watch later options conflict is found, specifically with `sub_margins` and `osd_margins` options
  - If `sub-pos` or `osd-margin-y` is found in watch later options, warn about the relevant option use
  - By default, `osd-margin-y` is not added to watch later options, check just in case it was added by user
- Remove deprecated options