### PR TITLE
fix: use direct property calls for pause

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3142,7 +3142,7 @@ local function osc_init()
         -- sent when the user is done seeking, so we need to throw away
         -- identical seeks
         state.playing_and_seeking = true
-        if not state.pause and user_opts.mouse_seek_pause then
+        if not mp.get_property_bool("pause") and user_opts.mouse_seek_pause then
             mp.commandv("cycle", "pause")
         end
         local seekto = get_slider_value(element)


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/593

**Changes**:
- Use direct property calls with element state `was_paused`
- Use direct property call for mouse drag on seek bar for `pause` state
- Revert `observe_cached()` for `pause`