### PR TITLE
fix: pause playback on seek handle click

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -3205,13 +3205,19 @@ local function osc_init()
     ne.eventresponder["mbtn_left_down"] = function (element)
         element.state.mbtnleft = true
         element.state.was_paused = mp.get_property_bool("pause")
-        state.playing_and_seeking = false  -- clear state
+        state.playing_and_seeking = true
+        if not element.state.was_paused and user_opts.mouse_seek_pause then
+            mp.commandv("cycle", "pause")
+        end
         mp.commandv("seek", get_slider_value(element), "absolute-percent+exact")
     end
     ne.eventresponder["shift+mbtn_left_down"] = function (element)
         element.state.mbtnleft = true
         element.state.was_paused = mp.get_property_bool("pause")
-        state.playing_and_seeking = false
+        state.playing_and_seeking = true
+        if not element.state.was_paused and user_opts.mouse_seek_pause then
+            mp.commandv("cycle", "pause")
+        end
         mp.commandv("seek", get_slider_value(element), "absolute-percent")
     end
     ne.eventresponder["mbtn_left_up"] = function (element)


### PR DESCRIPTION
Previously, when `mouse_seek_pause=yes` the video would not pause when clicking seek bar/handle until mouse is moved.

Now video pauses on mbtn_left_down (not wait for mouse_move).