### PR TITLE
feat: add seek_handle_border options

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -148,7 +148,8 @@ watch-later-options-remove=osd-margin-y
 | seekbarfg_color                   | `#FB8C00` | color of the seekbar progress                                                                     |
 | seekbarbg_color                   | `#94754F` | color of the remaining seekbar                                                                    |
 | seekbar_cache_color               | `#918F8E` | color of the cache ranges on the seekbar                                                          |
-| seek_handle_color                 | `#FB8C00` | color of the seekbar handle                                                                       |
+| seek_handle_color                 | `#94754F` | color of the seekbar handle                                                                       |
+| seek_handle_border_color          | `#FB8C00` | inner border color drawn inside the seekbar handle                                                |
 | volumebar_match_seek_color        | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
 | time_color                        | `#FFFFFF` | color of the timestamps (below seekbar)                                                           |
 | chapter_title_color               | `#FFFFFF` | color of the chapter title (above seekbar)                                                        |
@@ -187,10 +188,9 @@ watch-later-options-remove=osd-margin-y
 
 | Option                        | Value    | Description                                                             |
 | --------------------------    | -------- | ----------------------------------------------------------------------- |
-| seek_handle_size              | 1        | size ratio of the seekbar handle (range: 0 ~ 1)                         |
-| seek_handle_border_color      | `#454545`| inner border color drawn inside the seekbar handle                      |
-| seek_handle_border_size       | 0.45     | border thickness as a fraction of the handle radius                     |
-| seek_handle_border_hover_size | 0.28     | border thickness when handle is hovered                                 |
+| seek_handle_size              | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                         |
+| seek_handle_border_size       | 0.35     | border thickness as a fraction of the handle radius                     |
+| seek_handle_border_hover_size | 0.25     | border thickness when handle is hovered                                 |
 | seekbar_height                | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`             |
 | seekrange                     | yes      | show seek range overlay                                                 |
 | seekrangealpha                | 150      | transparency of the seek range                                          |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -145,11 +145,11 @@ watch-later-options-remove=osd-margin-y
 | windowcontrols_max_hover          | `#F8BC3A` | color of maximize window controls on hover                                                        |
 | windowcontrols_min_hover          | `#43CB44` | color of minimize window controls on hover                                                        |
 | title_color                       | `#FFFFFF` | color of the title (above seekbar)                                                                |
-| seekbarfg_color                   | `#FB8C00` | color of the seekbar progress                                                                     |
-| seekbarbg_color                   | `#94754F` | color of the remaining seekbar                                                                    |
-| seekbar_cache_color               | `#918F8E` | color of the cache ranges on the seekbar                                                          |
-| seek_handle_color                 | `#94754F` | color of the seekbar handle                                                                       |
-| seek_handle_border_color          | `#FB8C00` | inner border color drawn inside the seekbar handle                                                |
+| seekbar_cache_color               | `#FFFFFF` | color of the cache ranges on the seekbar                                                          |
+| seekbarfg_color                   | `#FF8232` | color of the seekbar progress                                                                     |
+| seekbarbg_color                   | `#999999` | color of the remaining seekbar                                                                    |
+| seek_handle_color                 | `#994D18` | color of the seekbar handle                                                                       |
+| seek_handle_border_color          | `#FF8232` | inner border color drawn inside the seekbar handle                                                |
 | volumebar_match_seek_color        | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
 | time_color                        | `#FFFFFF` | color of the timestamps (below seekbar)                                                           |
 | chapter_title_color               | `#FFFFFF` | color of the chapter title (above seekbar)                                                        |
@@ -158,10 +158,10 @@ watch-later-options-remove=osd-margin-y
 | middle_buttons_color              | `#FFFFFF` | color of the middle buttons (skip, jump, chapter, etc.)                                           |
 | playpause_color                   | `#FFFFFF` | color of the play/pause button                                                                    |
 | held_element_color                | `#999999` | color of the element when held down (pressed)                                                     |
-| hover_effect_color                | `#FB8C00` | color of a hovered button when `hover_effect` includes `"color"`                                  |
+| hover_effect_color                | `#FF8232` | color of a hovered button when `hover_effect` includes `"color"`                                  |
 | thumbnail_box_color               | `#111111` | color of the background for thumbnail box                                                         |
 | thumbnail_box_outline             | `#404040` | color of the border outline for thumbnail box                                                     |
-| nibble_color                      | `#FB8C00` | color of chapter nibbles on the seekbar                                                           |
+| nibble_color                      | `#FF8232` | color of chapter nibbles on the seekbar                                                           |
 | nibble_current_color              | `#FFFFFF` | color of the current chapter nibble on the seekbar                                                |
 | osc_fade_strength                 | 100       | strength of the OSC background fade (0 to disable)                                                |
 | fade_blur_strength                | 100       | blur strength for the OSC alpha fade. caution: high values can take a lot of CPU time to render   |
@@ -189,8 +189,8 @@ watch-later-options-remove=osd-margin-y
 | Option                        | Value    | Description                                                             |
 | --------------------------    | -------- | ----------------------------------------------------------------------- |
 | seek_handle_size              | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                         |
-| seek_handle_border_size       | 0.35     | border thickness as a fraction of the handle radius                     |
-| seek_handle_border_hover_size | 0.25     | border thickness when handle is hovered                                 |
+| seek_handle_border_size       | 0.42     | border thickness as a fraction of the handle radius                     |
+| seek_handle_border_hover_size | 0.31     | border thickness when handle is hovered                                 |
 | seekbar_height                | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`             |
 | seekrange                     | yes      | show seek range overlay                                                 |
 | seekrangealpha                | 150      | transparency of the seek range                                          |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -178,29 +178,31 @@ watch-later-options-remove=osd-margin-y
 | button_held_size      | 100                 | relative size of a button when held/pressed. below 100 shrinks button when held down                      |
 | button_held_box_alpha | 18                  | alpha of the hover background box when a button is held down                                              |
 | button_glow_amount    | 5                   | glow intensity when `"glow"` hover effect is active                                                       |
-| slider_hover_effect   | yes                 | apply size effect only when hovering slider handles                                                       |
-| slider_hover_size     | 130                 | relative size of a hovered slider handle if "slider_hover_effect" is used                                 |
+| slider_hover_size     | 100                 | relative size of a hovered slider handle (100 = no size change)                                           |
 | tooltip_hints         | yes                 | enable tooltips for most buttons. seek and volume tooltips are always enabled                             |
 
 ### Progress bar settings
 
-| Option                     | Value    | Description                                                             |
-| -------------------------- | -------- | ----------------------------------------------------------------------- |
-| seek_handle_size           | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                         |
-| seekbar_height             | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`             |
-| seekrange                  | yes      | show seek range overlay                                                 |
-| seekrangealpha             | 150      | transparency of the seek range                                          |
-| livemarkers                | yes      | update chapter markers on the seekbar when duration changes             |
-| seekbarkeyframes           | no       | use keyframes when dragging the seekbar                                 |
-| slider_rounded_corners     | yes      | rounded corners seekbar slider                                          |
-| nibbles_style              | gap      | chapter nibble style: `gap`, `triangle`, `bar` or `single-bar`          |
-| nibbles_top                | yes      | top chapter nibbles above seekbar                                       |
-| nibbles_bottom             | yes      | bottom chapter nibbles below seekbar                                    |
-| automatickeyframemode      | yes      | automatically set keyframes for the seekbar based on video length       |
-| automatickeyframelimit     | 600      | videos longer than this (in seconds) will have keyframes on the seekbar |
-| persistent_progress        | no       | always show a small progress line at the bottom of the screen           |
-| persistent_progress_height | 17       | height of the persistent progress bar                                   |
-| persistent_buffer          | no       | show cached buffer status in the persistent progress line               |
+| Option                        | Value    | Description                                                             |
+| --------------------------    | -------- | ----------------------------------------------------------------------- |
+| seek_handle_size              | 1        | size ratio of the seekbar handle (range: 0 ~ 1)                         |
+| seek_handle_border_color      | `#454545`| inner border color drawn inside the seekbar handle                      |
+| seek_handle_border_size       | 0.45     | border thickness as a fraction of the handle radius                     |
+| seek_handle_border_hover_size | 0.28     | border thickness when handle is hovered                                 |
+| seekbar_height                | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`             |
+| seekrange                     | yes      | show seek range overlay                                                 |
+| seekrangealpha                | 150      | transparency of the seek range                                          |
+| livemarkers                   | yes      | update chapter markers on the seekbar when duration changes             |
+| seekbarkeyframes              | no       | use keyframes when dragging the seekbar                                 |
+| slider_rounded_corners        | yes      | rounded corners seekbar slider                                          |
+| nibbles_style                 | gap      | chapter nibble style: `gap`, `triangle`, `bar` or `single-bar`          |
+| nibbles_top                   | yes      | top chapter nibbles above seekbar                                       |
+| nibbles_bottom                | yes      | bottom chapter nibbles below seekbar                                    |
+| automatickeyframemode         | yes      | automatically set keyframes for the seekbar based on video length       |
+| automatickeyframelimit        | 600      | videos longer than this (in seconds) will have keyframes on the seekbar |
+| persistent_progress           | no       | always show a small progress line at the bottom of the screen           |
+| persistent_progress_height    | 17       | height of the persistent progress bar                                   |
+| persistent_buffer             | no       | show cached buffer status in the persistent progress line               |
 
 ### Miscellaneous settings
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -218,16 +218,16 @@ windowcontrols_min_hover=#43CB44
 title_color=#FFFFFF
 # color of the cache information
 cache_info_color=#FFFFFF
-# color of the seekbar progress
-seekbarfg_color=#FB8C00
-# color of the remaining seekbar
-seekbarbg_color=#94754F
 # color of the cache ranges on the seekbar
-seekbar_cache_color=#918F8E
+seekbar_cache_color=#FFFFFF
+# color of the seekbar progress
+seekbarfg_color=#FF8232
+# color of the remaining seekbar
+seekbarbg_color=#999999
 # color of the seekbar handle
-seek_handle_color=#94754F
+seek_handle_color=#994D18
 # inner border color drawn inside the seekbar handle
-seek_handle_border_color=#FB8C00
+seek_handle_border_color=#FF8232
 # match volume bar color with seekbar color (ignores side_buttons_color)
 volumebar_match_seek_color=no
 # color of the timestamps (below seekbar)
@@ -243,13 +243,13 @@ playpause_color=#FFFFFF
 # color of the element when held down (pressed)
 held_element_color=#999999
 # color of a hovered button when hover_effect includes "color"
-hover_effect_color=#FB8C00
+hover_effect_color=#FF8232
 # color of the background for thumbnail box
 thumbnail_box_color=#111111
 # color of the border outline for thumbnail box
 thumbnail_box_outline=#404040
 # color of chapter nibbles on the seekbar
-nibble_color=#FB8C00
+nibble_color=#FF8232
 # color of the current chapter nibble on the seekbar
 nibble_current_color=#FFFFFF
 
@@ -290,9 +290,9 @@ tooltip_hints=yes
 # size ratio of the seekbar handle (range: 0 ~ 1)
 seek_handle_size=0.8
 # border thickness as a fraction of the handle radius
-seek_handle_border_size=0.35
+seek_handle_border_size=0.42
 # border thickness when handle is hovered
-seek_handle_border_hover_size=0.25
+seek_handle_border_hover_size=0.31
 # seekbar height preset: small, medium, large, xlarge
 seekbar_height=medium
 # show seek range overlay

--- a/modernz.conf
+++ b/modernz.conf
@@ -225,7 +225,9 @@ seekbarbg_color=#94754F
 # color of the cache ranges on the seekbar
 seekbar_cache_color=#918F8E
 # color of the seekbar handle
-seek_handle_color=#FB8C00
+seek_handle_color=#94754F
+# inner border color drawn inside the seekbar handle
+seek_handle_border_color=#FB8C00
 # match volume bar color with seekbar color (ignores side_buttons_color)
 volumebar_match_seek_color=no
 # color of the timestamps (below seekbar)
@@ -286,13 +288,11 @@ tooltip_hints=yes
 
 # Progress bar settings
 # size ratio of the seekbar handle (range: 0 ~ 1)
-seek_handle_size=1
-# inner border color drawn inside the seekbar handle
-seek_handle_border_color=#454545
+seek_handle_size=0.8
 # border thickness as a fraction of the handle radius
-seek_handle_border_size=0.45
+seek_handle_border_size=0.35
 # border thickness when handle is hovered
-seek_handle_border_hover_size=0.28
+seek_handle_border_hover_size=0.25
 # seekbar height preset: small, medium, large, xlarge
 seekbar_height=medium
 # show seek range overlay

--- a/modernz.conf
+++ b/modernz.conf
@@ -275,16 +275,20 @@ button_held_size=100
 button_held_box_alpha=18
 # glow intensity when "glow" hover effect is active
 button_glow_amount=5
-# apply size effect only when hovering slider handles
-slider_hover_effect=yes
-# relative size of a hovered slider handle if "slider_hover_effect" is used
-slider_hover_size=130
+# relative size of a hovered slider handle (100 = no size change)
+slider_hover_size=100
 # enable tooltips for most buttons. seek and volume tooltips are always enabled
 tooltip_hints=yes
 
 # Progress bar settings
 # size ratio of the seekbar handle (range: 0 ~ 1)
-seek_handle_size=0.8
+seek_handle_size=1
+# inner border color drawn inside the seekbar handle
+seek_handle_border_color=#454545
+# border thickness as a fraction of the handle radius
+seek_handle_border_size=0.45
+# border thickness when handle is hovered
+seek_handle_border_hover_size=0.28
 # seekbar height preset: small, medium, large, xlarge
 seekbar_height=medium
 # show seek range overlay

--- a/modernz.lua
+++ b/modernz.lua
@@ -140,11 +140,11 @@ local user_opts = {
     windowcontrols_min_hover = "#43CB44",  -- color of minimize window controls on hover
     title_color = "#FFFFFF",               -- color of the title (above seekbar)
     cache_info_color = "#FFFFFF",          -- color of the cache information
-    seekbarfg_color = "#FB8C00",           -- color of the seekbar progress
-    seekbarbg_color = "#94754F",           -- color of the remaining seekbar
-    seekbar_cache_color = "#918F8E",       -- color of the cache ranges on the seekbar
-    seek_handle_color = "#94754F",         -- color of the seekbar handle
-    seek_handle_border_color = "#FB8C00",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
+    seekbar_cache_color = "#FFFFFF",       -- color of the cache ranges on the seekbar
+    seekbarfg_color = "#FF8232",           -- color of the seekbar progress
+    seekbarbg_color = "#999999",           -- color of the remaining seekbar
+    seek_handle_color = "#994D18",         -- color of the seekbar handle
+    seek_handle_border_color = "#FF8232",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
     volumebar_match_seek_color = false,    -- match volume bar color with seekbar color (ignores side_buttons_color)
     time_color = "#FFFFFF",                -- color of the timestamps (below seekbar)
     chapter_title_color = "#FFFFFF",       -- color of the chapter title (above seekbar)
@@ -152,10 +152,10 @@ local user_opts = {
     middle_buttons_color = "#FFFFFF",      -- color of the middle buttons (skip, jump, chapter, etc.)
     playpause_color = "#FFFFFF",           -- color of the play/pause button
     held_element_color = "#999999",        -- color of the element when held down (pressed)
-    hover_effect_color = "#FB8C00",        -- color of a hovered button when hover_effect includes "color"
+    hover_effect_color = "#FF8232",        -- color of a hovered button when hover_effect includes "color"
     thumbnail_box_color = "#111111",       -- color of the background for thumbnail box
     thumbnail_box_outline = "#404040",     -- color of the border outline for thumbnail box
-    nibble_color = "#FB8C00",              -- color of chapter nibbles on the seekbar
+    nibble_color = "#FF8232",              -- color of chapter nibbles on the seekbar
     nibble_current_color = "#FFFFFF",      -- color of the current chapter nibble on the seekbar
 
     osc_fade_strength = 100,               -- strength of the OSC background fade (0 to disable)
@@ -178,8 +178,8 @@ local user_opts = {
 
     -- Progress bar settings
     seek_handle_size = 0.8,                -- size ratio of the seek handle (range: 0 ~ 1)
-    seek_handle_border_size = 0.35,        -- border thickness as a fraction of the handle radius
-    seek_handle_border_hover_size = 0.25,  -- border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
+    seek_handle_border_size = 0.42,        -- border thickness as a fraction of the handle radius
+    seek_handle_border_hover_size = 0.31,  -- border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
     seekbar_height = "medium",             -- seekbar height preset: "small", "medium", "large", "xlarge"
     seekrange = true,                      -- show seek range overlay
     seekrangealpha = 150,                  -- transparency of the seek range
@@ -1424,7 +1424,7 @@ local function draw_seekbar_nibbles(element, elem_ass)
 
     if slider_lo.nibbles_style == "gap" and element.name == "seekbar" then
         local radius = slider_lo.radius
-        local bg_alpha = 0
+        local bg_alpha = 128
         elem_ass:draw_stop()
         elem_ass:merge(element.style_ass)
         ass_append_alpha(elem_ass, element.layout.alpha, bg_alpha)
@@ -2187,7 +2187,7 @@ layouts["modern"] = function ()
     lo.layer = 15
     lo.style = osc_styles.seekbar_bg
     lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
-    lo.alpha[1] = 0
+    lo.alpha[1] = 128
 
     lo = add_layout("seekbar")
     local seekbar_h = 18
@@ -2319,7 +2319,7 @@ layouts["modern"] = function ()
         lo = add_layout("volumebarbg")
         lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 4}
         lo.layer = 15
-        lo.alpha[1] = 0
+        lo.alpha[1] = 128
         lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_bg or osc_styles.volumebar_bg
         lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 
@@ -2455,7 +2455,7 @@ layouts["modern-compact"] = function ()
     lo.layer = 15
     lo.style = osc_styles.seekbar_bg
     lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
-    lo.alpha[1] = 0
+    lo.alpha[1] = 128
 
     lo = add_layout("seekbar")
     local seekbar_h = 18
@@ -2585,7 +2585,7 @@ layouts["modern-compact"] = function ()
             lo = add_layout("volumebarbg")
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 4}
             lo.layer = 15
-            lo.alpha[1] = 0
+            lo.alpha[1] = 128
             lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_bg or osc_styles.volumebar_bg
             lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 
@@ -2709,7 +2709,7 @@ layouts["modern-image"] = function ()
         lo = add_layout("zoom_control_bg")
         lo.geometry = {x = zx + 25, y = refY - (user_opts.osc_height / 2), an = 4, w = 80, h = 4}
         lo.layer = 15
-        lo.alpha[1] = 0
+        lo.alpha[1] = 128
         lo.style = osc_styles.volumebar_bg
         lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 
@@ -3262,27 +3262,20 @@ local function osc_init()
             element.state.lastseek = seekto
         end
     end
-    local function seekbar_drag_start(element)
-        element.state.mbtnleft = true
-        local _, _, clicked_on_handle = get_seekbar_handle_pos(element)
-        element.state.handle_drag = clicked_on_handle
-        element.state.was_paused = mp.get_property_bool("pause")
-        state.playing_and_seeking = true
-        if not element.state.was_paused and user_opts.mouse_seek_pause then
-            mp.commandv("cycle", "pause")
-        end
-    end
     ne.eventresponder["mbtn_left_down"] = function (element)
-        seekbar_drag_start(element)
+        element.state.mbtnleft = true
+        element.state.was_paused = mp.get_property_bool("pause")
+        state.playing_and_seeking = false
         mp.commandv("seek", get_slider_value(element), "absolute-percent+exact")
     end
     ne.eventresponder["shift+mbtn_left_down"] = function (element)
-        seekbar_drag_start(element)
+        element.state.mbtnleft = true
+        element.state.was_paused = mp.get_property_bool("pause")
+        state.playing_and_seeking = false
         mp.commandv("seek", get_slider_value(element), "absolute-percent")
     end
     ne.eventresponder["mbtn_left_up"] = function (element)
         element.state.mbtnleft = false
-        element.state.handle_drag = false
         if state.playing_and_seeking then
             -- only unpause if the video was playing before the drag started
             if not element.state.was_paused and not mp.get_property_bool("eof-reached") and user_opts.mouse_seek_pause then
@@ -3311,7 +3304,6 @@ local function osc_init()
         element.state.lastseek = nil
         if element.state.mbtnleft then
             element.state.mbtnleft = false
-            element.state.handle_drag = false
             if state.playing_and_seeking then
                 if not element.state.was_paused and not mp.get_property_bool("eof-reached") and user_opts.mouse_seek_pause then
                     mp.commandv("cycle", "pause")

--- a/modernz.lua
+++ b/modernz.lua
@@ -170,12 +170,14 @@ local user_opts = {
     button_held_size = 100,                -- relative size of a button when held/pressed. below 100 shrinks button when held down
     button_held_box_alpha = 18,            -- alpha of the hover background box when a button is held down
     button_glow_amount = 5,                -- glow intensity when "glow" hover effect is active
-    slider_hover_effect = true,            -- apply size effect only when hovering slider handles
-    slider_hover_size = 130,               -- relative size of a hovered slider handle if "slider_hover_effect" is used
+    slider_hover_size = 100,               -- relative size of a hovered slider handle
     tooltip_hints = true,                  -- enable tooltips for most buttons. seek and volume tooltips are always enabled
 
     -- Progress bar settings
-    seek_handle_size = 0.8,                -- size ratio of the seek handle (range: 0 ~ 1)
+    seek_handle_size = 1,                  -- size ratio of the seek handle (range: 0 ~ 1)
+    seek_handle_border_color = "#454545",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
+    seek_handle_border_size = 0.45,        -- border thickness as a fraction of the handle radius
+    seek_handle_border_hover_size = 0.28,  -- border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
     seekbar_height = "medium",             -- seekbar height preset: "small", "medium", "large", "xlarge"
     seekrange = true,                      -- show seek range overlay
     seekrangealpha = 150,                  -- transparency of the seek range
@@ -1240,37 +1242,79 @@ local function get_chapter(possec)
     end
 end
 
--- Computes handle position and radius without drawing
--- Returns handle position and radius
+-- Computes the seekbar handle's screen position and radius, without drawing anything.
+-- Returns three values: xp (x position), rh (radius), is_active (hovered or being dragged).
 local function get_seekbar_handle_pos(element)
     local pos = element.slider.posF()
-    if not pos then return 0, 0 end
-    local display_handle = user_opts.seek_handle_size > 0
+    if not pos then return 0, 0, false end
     local elem_geo = element.layout.geometry
-    local rh = display_handle and (user_opts.seek_handle_size * elem_geo.h / 2) or 0
+    -- radius is a fraction of the element height, controlled by seek_handle_size (0 = hidden, 1 = full)
+    local rh = user_opts.seek_handle_size * elem_geo.h / 2
+    -- xp is the horizontal pixel offset from the left edge of the slider element
     local xp = get_slider_ele_pos_for(element, pos)
-    local handle_hovered = mouse_hit_coords(element.hitbox.x1 + xp - rh, element.hitbox.y1 + elem_geo.h / 2 - rh, element.hitbox.x1 + xp + rh, element.hitbox.y1 + elem_geo.h / 2 + rh) and element.enabled
-    if display_handle then
-        if (handle_hovered or element.state.mbtnleft) and user_opts.slider_hover_effect then
+    local handle_hovered = mouse_hit_coords(
+        element.hitbox.x1 + xp - rh, element.hitbox.y1 + elem_geo.h / 2 - rh,
+        element.hitbox.x1 + xp + rh, element.hitbox.y1 + elem_geo.h / 2 + rh
+    ) and element.enabled
+    local is_active = handle_hovered or element.state.handle_drag
+    if rh > 0 then
+        if is_active then
+            -- grow the handle while active, scaled by slider_hover_size
             rh = rh * (user_opts.slider_hover_size / 100)
+            -- clamp xp so the grown handle never overflows past the ends of the bar
+            xp = limit_range(rh, elem_geo.w - rh, xp)
         end
-        return xp, rh
+        return xp, rh, is_active
     end
-    return xp, 0
+    -- seek_handle_size is 0, handle is disabled
+    return xp, 0, false
 end
 
--- Draws a handle on the seekbar using precomputed position and radius
-local function draw_seekbar_handle(element, elem_ass, xp, rh)
-    if rh <= 0 then return end
-
+-- Resets the ASS drawing context and starts a new layer in the given fill color.
+-- Must be called before each ass_draw_cir_cw() call when drawing the handle,
+-- because each circle needs its own isolated style state (color, blur, border).
+-- Without this reset, the color from a previous draw call would bleed through.
+local function handle_begin_layer(element, elem_ass, color, anim_override)
     elem_ass:draw_stop()
     elem_ass:merge(element.style_ass)
-    ass_append_alpha(elem_ass, element.layout.alpha, 0)
-    if element.name == "seekbar" then
-        elem_ass:append("{\\blur0\\bord0\\1c&H" .. osc_color_convert(user_opts.seek_handle_color) .. "&}")
-    end
+    ass_append_alpha(elem_ass, element.layout.alpha, 0, nil, anim_override)
+    elem_ass:append("{\\blur0\\bord0\\1c&H" .. osc_color_convert(color) .. "&}")
     elem_ass:merge(element.static_ass)
-    ass_draw_cir_cw(elem_ass, xp, element.layout.geometry.h / 2, rh)
+end
+
+-- Draws the seekbar handle at the precomputed position (xp) and radius (rh).
+-- If a border is configured, two concentric circles are drawn using the painter's algorithm:
+--   1. A larger outer circle in the border color  (radius = rh)
+--   2. A smaller inner circle in the fill color   (radius = inner_radius)
+-- The outer circle's rim that isn't covered by the inner circle becomes the visible border ring.
+
+local function draw_seekbar_handle(element, elem_ass, xp, rh, anim_override, handle_hovered)
+    if rh <= 0 then return end
+
+    local cy = element.layout.geometry.h / 2   -- vertical center of the element
+    local slider_lo = element.layout.slider
+    -- pick fill color from the slider's layout (set per-slider in layouts), fall back to side buttons color
+    local fill_color = slider_lo.handle_color or user_opts.side_buttons_color
+    -- border thickness as a ratio of rh: shrinks on hover to give a subtle active state
+    local border_ratio = handle_hovered and user_opts.seek_handle_border_hover_size or user_opts.seek_handle_border_size
+    local border_color = slider_lo.handle_border and border_ratio > 0 and slider_lo.handle_border
+    local has_border = border_color ~= nil and border_color ~= false
+
+    if has_border then
+        -- inner_radius is how far the fill circle extends inward from the outer edge
+        -- e.g. border_ratio=0.45, rh=10 → inner_radius=5.5, leaving a 4.5px border ring
+        local inner_radius = rh * (1 - border_ratio)
+
+        handle_begin_layer(element, elem_ass, border_color, anim_override)
+        ass_draw_cir_cw(elem_ass, xp, cy, rh)           -- outer circle: border color fills the full handle area
+
+        handle_begin_layer(element, elem_ass, fill_color, anim_override)
+        ass_draw_cir_cw(elem_ass, xp, cy, inner_radius) -- inner circle: fill color painted on top, hiding the center
+    else
+        -- no border configured, just draw a single solid circle
+        handle_begin_layer(element, elem_ass, fill_color, anim_override)
+        ass_draw_cir_cw(elem_ass, xp, cy, rh)
+    end
 end
 
 -- Collects and sorts pixel cut positions for gap-style chapter markers.
@@ -1571,10 +1615,10 @@ local function render_elements(master_ass, osc_vis, wc_vis)
                 ass_append_alpha(elem_ass, element.layout.alpha, 0, nil, anim_override)
                 elem_ass:merge(element.static_ass)
 
-                local xp, rh = get_seekbar_handle_pos(element) -- get handle position/radius
+                local xp, rh, handle_hovered = get_seekbar_handle_pos(element) -- get handle position/radius
                 draw_seekbar_progress(element, elem_ass)
                 draw_seekbar_ranges(element, elem_ass, xp, rh)
-                draw_seekbar_handle(element, elem_ass, xp, rh) -- draw handle on top of progress
+                draw_seekbar_handle(element, elem_ass, xp, rh, anim_override, handle_hovered) -- draw handle on top of progress
 
                 elem_ass:draw_stop()
 
@@ -2149,6 +2193,8 @@ layouts["modern"] = function ()
     lo.geometry = {x = refX, y = refY - user_opts.osc_height, an = 5, w = osc_geo.w - 30, h = seekbar_h}
     lo.layer = 49
     lo.style = osc_styles.seekbar_fg
+    lo.slider.handle_color = user_opts.seek_handle_color
+    lo.slider.handle_border = user_opts.seek_handle_border_color
     lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
     lo.slider.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
     lo.slider.tooltip_an = 2
@@ -2280,6 +2326,7 @@ layouts["modern"] = function ()
         lo = add_layout("volumebar")
         lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 10}
         lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_fg or osc_styles.volumebar_fg
+        lo.slider.handle_color = user_opts.volumebar_match_seek_color and user_opts.seekbarfg_color or user_opts.side_buttons_color
         lo.slider.gap = 3
         lo.slider.radius = user_opts.slider_rounded_corners and 2 or 0
         lo.slider.tooltip_an = 2
@@ -2415,6 +2462,8 @@ layouts["modern-compact"] = function ()
     lo.geometry = {x = refX, y = refY - user_opts.osc_height, an = 5, w = osc_geo.w - 30, h = seekbar_h}
     lo.layer = 49
     lo.style = osc_styles.seekbar_fg
+    lo.slider.handle_color = user_opts.seek_handle_color
+    lo.slider.handle_border = user_opts.seek_handle_border_color
     lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
     lo.slider.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
     lo.slider.tooltip_an = 2
@@ -2543,6 +2592,7 @@ layouts["modern-compact"] = function ()
             lo = add_layout("volumebar")
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 10}
             lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_fg or osc_styles.volumebar_fg
+            lo.slider.handle_color = user_opts.volumebar_match_seek_color and user_opts.seekbarfg_color or user_opts.side_buttons_color
             lo.slider.gap = 3
             lo.slider.radius = user_opts.slider_rounded_corners and 2 or 0
             lo.slider.tooltip_an = 2
@@ -2667,6 +2717,7 @@ layouts["modern-image"] = function ()
         lo = add_layout("zoom_control")
         lo.geometry = {x = zx + 25, y = refY - (user_opts.osc_height / 2), an = 4, w = 80, h = 10}
         lo.style = osc_styles.volumebar_fg
+        lo.slider.handle_color = user_opts.side_buttons_color
         lo.slider.radius = user_opts.slider_rounded_corners and 2 or 0
         lo.slider.gap = 3
         lo.slider.tooltip_an = 2
@@ -3004,6 +3055,7 @@ local function osc_init()
     end
     ne.eventresponder["mbtn_left_up"] = function (element)
         element.state.mbtnleft = false
+        element.state.handle_drag = false
     end
     ne.eventresponder["reset"] = function (element)
         element.state.lastseek = nil
@@ -3211,26 +3263,27 @@ local function osc_init()
             element.state.lastseek = seekto
         end
     end
-    ne.eventresponder["mbtn_left_down"] = function (element)
+    local function seekbar_drag_start(element)
         element.state.mbtnleft = true
+        local _, _, hovered = get_seekbar_handle_pos(element)
+        element.state.handle_drag = hovered
         element.state.was_paused = mp.get_property_bool("pause")
         state.playing_and_seeking = true
         if not element.state.was_paused and user_opts.mouse_seek_pause then
             mp.commandv("cycle", "pause")
         end
+    end
+    ne.eventresponder["mbtn_left_down"] = function (element)
+        seekbar_drag_start(element)
         mp.commandv("seek", get_slider_value(element), "absolute-percent+exact")
     end
     ne.eventresponder["shift+mbtn_left_down"] = function (element)
-        element.state.mbtnleft = true
-        element.state.was_paused = mp.get_property_bool("pause")
-        state.playing_and_seeking = true
-        if not element.state.was_paused and user_opts.mouse_seek_pause then
-            mp.commandv("cycle", "pause")
-        end
+        seekbar_drag_start(element)
         mp.commandv("seek", get_slider_value(element), "absolute-percent")
     end
     ne.eventresponder["mbtn_left_up"] = function (element)
         element.state.mbtnleft = false
+        element.state.handle_drag = false
         if state.playing_and_seeking then
             -- only unpause if the video was playing before the drag started
             if not element.state.was_paused and not mp.get_property_bool("eof-reached") and user_opts.mouse_seek_pause then
@@ -3259,6 +3312,7 @@ local function osc_init()
         element.state.lastseek = nil
         if element.state.mbtnleft then
             element.state.mbtnleft = false
+            element.state.handle_drag = false
             if state.playing_and_seeking then
                 if not element.state.was_paused and not mp.get_property_bool("eof-reached") and user_opts.mouse_seek_pause then
                     mp.commandv("cycle", "pause")
@@ -4047,8 +4101,8 @@ local function validate_user_opts()
         user_opts.window_controls_color, user_opts.held_element_color, user_opts.thumbnail_box_color,
         user_opts.chapter_title_color, user_opts.seekbar_cache_color, user_opts.hover_effect_color,
         user_opts.windowcontrols_close_hover, user_opts.windowcontrols_max_hover, user_opts.windowcontrols_min_hover,
-        user_opts.cache_info_color, user_opts.thumbnail_box_outline,
-        user_opts.nibble_color, user_opts.nibble_current_color, user_opts.seek_handle_color,
+        user_opts.cache_info_color, user_opts.thumbnail_box_outline, user_opts.nibble_color, user_opts.nibble_current_color,
+        user_opts.seek_handle_color, user_opts.seek_handle_border_color
     }
 
     for _, color in pairs(colors) do

--- a/modernz.lua
+++ b/modernz.lua
@@ -1245,39 +1245,39 @@ local function get_chapter(possec)
     end
 end
 
--- Computes the seekbar handle's screen position and radius, without drawing anything.
--- Returns three values: xp (x position), rh (radius), is_active (hovered or being dragged).
+-- Computes handle position and radius without drawing
+-- Returns handle position, radius, and whether the handle is active (hovered or dragged)
 local function get_seekbar_handle_pos(element)
     local pos = element.slider.posF()
     if not pos then return 0, 0, false end
+
     local elem_geo = element.layout.geometry
-    -- radius is a fraction of the element height, controlled by seek_handle_size (0 = hidden, 1 = full)
-    local rh = user_opts.seek_handle_size * elem_geo.h / 2
-    -- xp is the horizontal pixel offset from the left edge of the slider element
-    local xp = get_slider_ele_pos_for(element, pos)
-    local handle_hovered = mouse_hit_coords(
-        element.hitbox.x1 + xp - rh, element.hitbox.y1 + elem_geo.h / 2 - rh,
-        element.hitbox.x1 + xp + rh, element.hitbox.y1 + elem_geo.h / 2 + rh
+    local handle_radius = user_opts.seek_handle_size * elem_geo.h / 2
+    local handle_x = get_slider_ele_pos_for(element, pos)
+    local center_y = elem_geo.h / 2
+
+    local mouse_over_handle = mouse_hit_coords(
+        element.hitbox.x1 + handle_x - handle_radius,
+        element.hitbox.y1 + center_y - handle_radius,
+        element.hitbox.x1 + handle_x + handle_radius,
+        element.hitbox.y1 + center_y + handle_radius
     ) and element.enabled
-    local is_active = handle_hovered or element.state.handle_drag
-    if rh > 0 then
+
+    local is_active = mouse_over_handle or element.state.handle_drag
+
+    if handle_radius > 0 then
         if is_active then
-            -- grow the handle while active, scaled by slider_hover_size
-            rh = rh * (user_opts.slider_hover_size / 100)
-            -- clamp xp so the grown handle never overflows past the ends of the bar
-            xp = limit_range(rh, elem_geo.w - rh, xp)
+            handle_radius = handle_radius * (user_opts.slider_hover_size / 100)
+            handle_x = limit_range(handle_radius, elem_geo.w - handle_radius, handle_x)
         end
-        return xp, rh, is_active
+        return handle_x, handle_radius, is_active
     end
-    -- seek_handle_size is 0, handle is disabled
-    return xp, 0, false
+
+    return handle_x, 0, false
 end
 
--- Resets the ASS drawing context and starts a new layer in the given fill color.
--- Must be called before each ass_draw_cir_cw() call when drawing the handle,
--- because each circle needs its own isolated style state (color, blur, border).
--- Without this reset, the color from a previous draw call would bleed through.
-local function handle_begin_layer(element, elem_ass, color, anim_override)
+-- Prepares elem_ass for a new draw layer with the given color
+local function begin_draw_layer(element, elem_ass, color, anim_override)
     elem_ass:draw_stop()
     elem_ass:merge(element.style_ass)
     ass_append_alpha(elem_ass, element.layout.alpha, 0, nil, anim_override)
@@ -1285,38 +1285,32 @@ local function handle_begin_layer(element, elem_ass, color, anim_override)
     elem_ass:merge(element.static_ass)
 end
 
--- Draws the seekbar handle at the precomputed position (xp) and radius (rh).
--- If a border is configured, two concentric circles are drawn using the painter's algorithm:
---   1. A larger outer circle in the border color  (radius = rh)
---   2. A smaller inner circle in the fill color   (radius = inner_radius)
--- The outer circle's rim that isn't covered by the inner circle becomes the visible border ring.
+-- Draws a handle on the seekbar using precomputed position and radius
+local function draw_seekbar_handle(element, elem_ass, handle_x, handle_radius, anim_override, is_active)
+    if handle_radius <= 0 then return end
 
-local function draw_seekbar_handle(element, elem_ass, xp, rh, anim_override, handle_hovered)
-    if rh <= 0 then return end
-
-    local cy = element.layout.geometry.h / 2   -- vertical center of the element
+    local center_y = element.layout.geometry.h / 2
     local slider_lo = element.layout.slider
-    -- pick fill color from the slider's layout (set per-slider in layouts), fall back to side buttons color
+
     local fill_color = slider_lo.handle_color or user_opts.side_buttons_color
-    -- border thickness as a ratio of rh: shrinks on hover to give a subtle active state
-    local border_ratio = handle_hovered and user_opts.seek_handle_border_hover_size or user_opts.seek_handle_border_size
-    local border_color = slider_lo.handle_border and border_ratio > 0 and slider_lo.handle_border
-    local has_border = border_color ~= nil and border_color ~= false
+    local border_color = slider_lo.handle_border
+    local border_thickness = is_active
+        and user_opts.seek_handle_border_hover_size
+        or  user_opts.seek_handle_border_size
+    local has_border = border_color and border_color ~= "" and border_thickness > 0
 
     if has_border then
         -- inner_radius is how far the fill circle extends inward from the outer edge
-        -- e.g. border_ratio=0.45, rh=10 → inner_radius=5.5, leaving a 4.5px border ring
-        local inner_radius = rh * (1 - border_ratio)
-
-        handle_begin_layer(element, elem_ass, border_color, anim_override)
-        ass_draw_cir_cw(elem_ass, xp, cy, rh)           -- outer circle: border color fills the full handle area
-
-        handle_begin_layer(element, elem_ass, fill_color, anim_override)
-        ass_draw_cir_cw(elem_ass, xp, cy, inner_radius) -- inner circle: fill color painted on top, hiding the center
+        local inner_radius = handle_radius * (1 - border_thickness)
+        -- full circle in border color, then smaller circle in fill color on top
+        begin_draw_layer(element, elem_ass, border_color, anim_override)
+        ass_draw_cir_cw(elem_ass, handle_x, center_y, handle_radius)
+        begin_draw_layer(element, elem_ass, fill_color, anim_override)
+        ass_draw_cir_cw(elem_ass, handle_x, center_y, inner_radius)
     else
         -- no border configured, just draw a single solid circle
-        handle_begin_layer(element, elem_ass, fill_color, anim_override)
-        ass_draw_cir_cw(elem_ass, xp, cy, rh)
+        begin_draw_layer(element, elem_ass, fill_color, anim_override)
+        ass_draw_cir_cw(elem_ass, handle_x, center_y, handle_radius)
     end
 end
 
@@ -1618,10 +1612,10 @@ local function render_elements(master_ass, osc_vis, wc_vis)
                 ass_append_alpha(elem_ass, element.layout.alpha, 0, nil, anim_override)
                 elem_ass:merge(element.static_ass)
 
-                local xp, rh, handle_hovered = get_seekbar_handle_pos(element) -- get handle position/radius
+                local handle_x, handle_radius, is_active = get_seekbar_handle_pos(element) -- get handle position/radius
                 draw_seekbar_progress(element, elem_ass)
-                draw_seekbar_ranges(element, elem_ass, xp, rh)
-                draw_seekbar_handle(element, elem_ass, xp, rh, anim_override, handle_hovered) -- draw handle on top of progress
+                draw_seekbar_ranges(element, elem_ass, handle_x, handle_radius)
+                draw_seekbar_handle(element, elem_ass, handle_x, handle_radius, anim_override, is_active) -- draw handle on top of progress
 
                 elem_ass:draw_stop()
 
@@ -3267,8 +3261,8 @@ local function osc_init()
     end
     local function seekbar_drag_start(element)
         element.state.mbtnleft = true
-        local _, _, hovered = get_seekbar_handle_pos(element)
-        element.state.handle_drag = hovered
+        local _, _, clicked_on_handle = get_seekbar_handle_pos(element)
+        element.state.handle_drag = clicked_on_handle
         element.state.was_paused = mp.get_property_bool("pause")
         state.playing_and_seeking = true
         if not element.state.was_paused and user_opts.mouse_seek_pause then
@@ -4123,8 +4117,12 @@ local function validate_user_opts()
         user_opts.chapter_title_color, user_opts.seekbar_cache_color, user_opts.hover_effect_color,
         user_opts.windowcontrols_close_hover, user_opts.windowcontrols_max_hover, user_opts.windowcontrols_min_hover,
         user_opts.cache_info_color, user_opts.thumbnail_box_outline, user_opts.nibble_color, user_opts.nibble_current_color,
-        user_opts.seek_handle_color, user_opts.seek_handle_border_color
+        user_opts.seek_handle_color,
     }
+
+    if user_opts.seek_handle_border_color ~= "" then
+        colors[#colors + 1] = user_opts.seek_handle_border_color
+    end
 
     for _, color in pairs(colors) do
         if color:find("^#%x%x%x%x%x%x$") == nil then

--- a/modernz.lua
+++ b/modernz.lua
@@ -143,7 +143,8 @@ local user_opts = {
     seekbarfg_color = "#FB8C00",           -- color of the seekbar progress
     seekbarbg_color = "#94754F",           -- color of the remaining seekbar
     seekbar_cache_color = "#918F8E",       -- color of the cache ranges on the seekbar
-    seek_handle_color = "#FB8C00",         -- color of the seekbar handle
+    seek_handle_color = "#94754F",         -- color of the seekbar handle
+    seek_handle_border_color = "#FB8C00",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
     volumebar_match_seek_color = false,    -- match volume bar color with seekbar color (ignores side_buttons_color)
     time_color = "#FFFFFF",                -- color of the timestamps (below seekbar)
     chapter_title_color = "#FFFFFF",       -- color of the chapter title (above seekbar)
@@ -176,10 +177,9 @@ local user_opts = {
     tooltip_hints = true,                  -- enable tooltips for most buttons. seek and volume tooltips are always enabled
 
     -- Progress bar settings
-    seek_handle_size = 1,                  -- size ratio of the seek handle (range: 0 ~ 1)
-    seek_handle_border_color = "#454545",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
-    seek_handle_border_size = 0.45,        -- border thickness as a fraction of the handle radius
-    seek_handle_border_hover_size = 0.28,  -- border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
+    seek_handle_size = 0.8,                -- size ratio of the seek handle (range: 0 ~ 1)
+    seek_handle_border_size = 0.35,        -- border thickness as a fraction of the handle radius
+    seek_handle_border_hover_size = 0.25,  -- border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
     seekbar_height = "medium",             -- seekbar height preset: "small", "medium", "large", "xlarge"
     seekrange = true,                      -- show seek range overlay
     seekrangealpha = 150,                  -- transparency of the seek range
@@ -1217,7 +1217,9 @@ local function prepare_elements()
         -- if the element is supposed to be disabled,
         -- style it accordingly and kill the eventresponders
         if not element.enabled then
-            element.layout.alpha[1] = 215
+            if element.name ~= "seekbar" then
+                element.layout.alpha[1] = 215
+            end
             if not (element.name == "sub_track" or element.name == "audio_track" or element.name == "playlist") then -- keep these to display tooltips
                 element.eventresponder = nil
             end
@@ -1379,7 +1381,7 @@ local function draw_seekbar_ranges(element, elem_ass, xp, rh, override_alpha, in
     end
 
     for _, range in pairs(seekRanges) do
-        local pstart = math.max(0, get_slider_ele_pos_for(element, range["start"]) - slider_lo.gap)
+        local pstart = math.max(xp, get_slider_ele_pos_for(element, range["start"]) - slider_lo.gap)
         local pend = math.min(elem_geo.w, get_slider_ele_pos_for(element, range["end"]) + slider_lo.gap)
 
         -- round edge only when cache range reaches start/end
@@ -1422,7 +1424,7 @@ local function draw_seekbar_nibbles(element, elem_ass)
 
     if slider_lo.nibbles_style == "gap" and element.name == "seekbar" then
         local radius = slider_lo.radius
-        local bg_alpha = elements["seekbarbg"] and elements["seekbarbg"].layout.alpha[1] or 128
+        local bg_alpha = 0
         elem_ass:draw_stop()
         elem_ass:merge(element.style_ass)
         ass_append_alpha(elem_ass, element.layout.alpha, bg_alpha)
@@ -1834,10 +1836,13 @@ local function render_persistent_progress(master_ass)
         elem_ass:merge(element.static_ass)
 
         -- draw pos marker
+        local pos = element.slider.posF and element.slider.posF()
+        local xp = pos and get_slider_ele_pos_for(element, pos) or 0
+
         draw_seekbar_progress(element, elem_ass)
 
         if user_opts.persistent_buffer then
-            draw_seekbar_ranges(element, elem_ass, nil, nil, nil, true)
+            draw_seekbar_ranges(element, elem_ass, xp, 0, nil, true)
         end
 
         elem_ass:draw_stop()
@@ -2182,8 +2187,7 @@ layouts["modern"] = function ()
     lo.layer = 15
     lo.style = osc_styles.seekbar_bg
     lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
-    lo.alpha[1] = 128
-    lo.alpha[3] = 128
+    lo.alpha[1] = 0
 
     lo = add_layout("seekbar")
     local seekbar_h = 18
@@ -2315,7 +2319,7 @@ layouts["modern"] = function ()
         lo = add_layout("volumebarbg")
         lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 4}
         lo.layer = 15
-        lo.alpha[1] = 128
+        lo.alpha[1] = 0
         lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_bg or osc_styles.volumebar_bg
         lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 
@@ -2451,8 +2455,7 @@ layouts["modern-compact"] = function ()
     lo.layer = 15
     lo.style = osc_styles.seekbar_bg
     lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
-    lo.alpha[1] = 152
-    lo.alpha[3] = 128
+    lo.alpha[1] = 0
 
     lo = add_layout("seekbar")
     local seekbar_h = 18
@@ -2582,7 +2585,7 @@ layouts["modern-compact"] = function ()
             lo = add_layout("volumebarbg")
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 4, w = 55, h = 4}
             lo.layer = 15
-            lo.alpha[1] = 128
+            lo.alpha[1] = 0
             lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_bg or osc_styles.volumebar_bg
             lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 
@@ -2706,7 +2709,7 @@ layouts["modern-image"] = function ()
         lo = add_layout("zoom_control_bg")
         lo.geometry = {x = zx + 25, y = refY - (user_opts.osc_height / 2), an = 4, w = 80, h = 4}
         lo.layer = 15
-        lo.alpha[1] = 128
+        lo.alpha[1] = 0
         lo.style = osc_styles.volumebar_bg
         lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
 


### PR DESCRIPTION
Adds a border to seekbar handle with related options for color, thickness, and hover thickness expressed as a ratio.

Changed slider_hover_size default value to 100 with toggle removed. Slightly increased handle sizes.

If accepted, will update docs later.