### PR TITLE
docs: add ModernZ menu items for context-menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,36 @@ If you find the seek bar too thin or too thick, you can easily adjust its size u
     </tr>
 </table>
 
+### Chapter Markers
+You can change the chapter markers style by using the `nibbles_style` option, which accepts: `gap`, `triangle`, `bar`, and `single-bar`
+
+<table>
+    <tr>
+        <th><code>gap</code> (Default)</th>
+        <th><code>triangle</code></th>
+    </tr>
+    <tr>
+        <td>
+            <img width="500" height="110" alt="chapter_gap" src="https://github.com/user-attachments/assets/c89cf611-36ec-4668-86ca-c4b4ebd73122" />
+        </td>
+        <td>
+            <img width="500" height="110" alt="chapter_triangle" src="https://github.com/user-attachments/assets/2cfc504e-086c-4392-bab9-aff90b0fac0c" />
+        </td>
+    </tr>
+    <tr>
+        <th><code>bar</code></th>
+        <th><code>single-bar</code></th>
+    </tr>
+    <tr>
+        <td>
+            <img width="500" height="110" alt="chapter_bar" src="https://github.com/user-attachments/assets/b609661d-8ec3-4146-ba3c-853dc802e64f" />
+        </td>
+        <td>
+            <img width="500" height="110" alt="chapter_singlebar" src="https://github.com/user-attachments/assets/03696a4c-8dc5-44f6-8090-b27e01562526" />
+        </td>
+    </tr>
+</table>
+
 ### Colors
 
 Not a fan of white buttons and text? You have complete control to customize colors to perfectly reflect your style.
@@ -273,12 +303,12 @@ For a full list of interactions, check out the [Button Interactions Guide](/docs
 ModernZ doesn't set keybinds by default to avoid interfering with your current setup. You can add keybinds in `input.conf` if you prefer:
 
 ```
-v   script-binding modernz/visibility               # Cycle visibility modes
-V   script-message-to modernz osc-visibility cycle  # Set a visibility mode: cycle, auto, always, never
-w   script-binding modernz/progress-toggle          # Toggle progress bar
-x   script-message-to modernz osc-show              # Show OSC
-y   script-message-to modernz osc-hide              # Hide OSC
-z   script-message-to modernz osc-idlescreen        # Toggle idle screen
+v   script-binding modernz/visibility              # Cycle visibility modes
+V   script-message-to modernz osc-visibility cycle # Set a visibility mode: cycle, auto, always, never
+w   script-binding modernz/progress-toggle         # Toggle persistent progress
+x   script-message-to modernz osc-show             # Show OSC
+y   script-message-to modernz osc-hide             # Hide OSC
+z   script-message-to modernz osc-idlescreen       # Toggle idle screen
 ```
 
 ## Translations

--- a/docs/INTERACTIVE_MENUS.md
+++ b/docs/INTERACTIVE_MENUS.md
@@ -17,7 +17,7 @@ For detailed information on how to interact with these controls, please refer to
 ## Context Menu
 For the best experience, make sure you’re running the latest version of mpv (git/master) to take advantage of all recently added features.
 
-<img width="985" height="587" alt="image" src="https://github.com/user-attachments/assets/33131b6c-5e56-4f64-bb9a-e6d91e1bbf06" />
+<img width="985" height="587" alt="modernz-menu" src="https://github.com/user-attachments/assets/33131b6c-5e56-4f64-bb9a-e6d91e1bbf06" />
 
 To enable context-menu:
 - Bind context menu in your `input.conf`

--- a/docs/INTERACTIVE_MENUS.md
+++ b/docs/INTERACTIVE_MENUS.md
@@ -1,6 +1,6 @@
 ## Interactive Menus
 
-https://github.com/user-attachments/assets/a12be7c5-9d14-41f7-8b04-bc63d79c4213
+https://github.com/user-attachments/assets/43b92663-d69a-4549-87cd-e60cff89d395
 
 ModernZ integrates mpv’s built-in [`console.lua`](https://github.com/mpv-player/mpv/blob/master/player/lua/console.lua) and [`select.lua`](https://github.com/mpv-player/mpv/blob/master/player/lua/select.lua) scripts, available in mpv starting from **v0.39+**.
 

--- a/docs/INTERACTIVE_MENUS.md
+++ b/docs/INTERACTIVE_MENUS.md
@@ -15,14 +15,9 @@ These integrations are accessible through the following interface elements:
 For detailed information on how to interact with these controls, please refer to the [Controls Manual](/docs/CONTROLS.md).
 
 ## Context Menu
-For the best experience, make sure you’re running the latest version of mpv (git/master) to take advantage of all recently added features, especially when using the `modern-compact` layout.
+For the best experience, make sure you’re running the latest version of mpv (git/master) to take advantage of all recently added features.
 
-Because the new layout is more compact, additional options remain easily accessible via: (thanks to @guidocella)
-
-- Right-click the **Playlist** button (Menu)
-- Open the new **Context Menu**
-
-![modernz-menu-context](https://github.com/user-attachments/assets/b345c64b-3a9e-4885-9340-0d224a43e40d)
+<img width="985" height="587" alt="image" src="https://github.com/user-attachments/assets/33131b6c-5e56-4f64-bb9a-e6d91e1bbf06" />
 
 To enable context-menu:
 - Bind context menu in your `input.conf`
@@ -30,8 +25,58 @@ To enable context-menu:
 - Optional: To adjust the context menu, you can use the default [menu.conf](https://github.com/mpv-player/mpv/blob/master/etc/menu.conf) as a reference
   - Place your modified `menu.conf` in your mpv config folder, same location as `mpv.conf`
   - As an example, here is a modified [menu.conf](https://github.com/Samillion/mpv-conf/blob/master/menu.conf)
+  - To not use native OS context-menu, you can add `load-context-menu=yes` to your `mpv.conf`.
 
-Additionally, to not use native Windows context-menu, you can add `load-context-menu=yes` to your `mpv.conf`.
+#### Context menu list for ModernZ in `menu.conf`:
+
+You can add or remove any of the list items to suit your needs. [[full list of ModernZ options](/docs/USER_OPTS.md)]
+
+```
+
+&ModernZ
+	&Layout
+		&Modern				no-osd change-list script-opts append modernz-layout=modern
+		Modern &Compact		no-osd change-list script-opts append modernz-layout=modern-compact
+
+	&Theme
+		&Icon Theme
+            &Fluent		no-osd change-list script-opts append modernz-icon_theme=fluent
+            &Material	no-osd change-list script-opts append modernz-icon_theme=material
+		Icon &Style
+            &Mixed		no-osd change-list script-opts append modernz-icon_style=mixed
+            &Filled		no-osd change-list script-opts append modernz-icon_style=filled
+            &Outline	no-osd change-list script-opts append modernz-icon_style=outline
+
+	&Seekbar
+        &Persistent Progress	script-binding modernz/progress-toggle
+        &Seekbar Height
+            &small		no-osd change-list script-opts append modernz-seekbar_height=small
+            &medium		no-osd change-list script-opts append modernz-seekbar_height=medium
+            &large		no-osd change-list script-opts append modernz-seekbar_height=large
+            &xlarge		no-osd change-list script-opts append modernz-seekbar_height=xlarge
+        &Chapter Marker
+            &gap			no-osd change-list script-opts append modernz-nibbles_style=gap
+            &triangle		no-osd change-list script-opts append modernz-nibbles_style=triangle
+            &bar			no-osd change-list script-opts append modernz-nibbles_style=bar
+            &single-bar		no-osd change-list script-opts append modernz-nibbles_style=single-bar
+
+	&Cycle OSC visibility	script-binding modernz/visibility
+
+	L&anguage
+		Defa&ult				no-osd change-list script-opts append modernz-language=default
+		&Arabic					no-osd change-list script-opts append modernz-language=ar
+		&Danish					no-osd change-list script-opts append modernz-language=dk
+		&English				no-osd change-list script-opts append modernz-language=en
+		&French					no-osd change-list script-opts append modernz-language=fr
+		&German					no-osd change-list script-opts append modernz-language=de
+		&Icelandic				no-osd change-list script-opts append modernz-language=is
+		&Japanese				no-osd change-list script-opts append modernz-language=jp
+		&Polish					no-osd change-list script-opts append modernz-language=pl
+		&Russian				no-osd change-list script-opts append modernz-language=ru
+		&Spanish				no-osd change-list script-opts append modernz-language=es
+		Simplified &Chinese		no-osd change-list script-opts append modernz-language=zh
+
+```
 
 ### Open File Dialog (Optional)
 The solution below only works for Windows, however you can search for one that works for your operating system in [mpv user scripts](https://github.com/mpv-player/mpv/wiki/User-Scripts) or [awesome-mpv](https://github.com/stax76/awesome-mpv), then apply it the same way.


### PR DESCRIPTION
Inspired by: https://github.com/mpv-player/mpv/pull/17733

**Changes**: 
Explain how to add a ModernZ menu list for context-menu (`menu.conf`)

<img width="985" height="587" alt="modernz-menu" src="https://github.com/user-attachments/assets/33131b6c-5e56-4f64-bb9a-e6d91e1bbf06" />