### PR TITLE
pause-indicator: add option to hide indicator when dragging seekbar

### DIFF
--- a/extras/pause-indicator-lite/README.md
+++ b/extras/pause-indicator-lite/README.md
@@ -46,6 +46,7 @@ To adjust them you can either:
 | `mute_indicator`         | no              | show a mute indicator                                                                                                                      |
 | `mute_indicator_pos`     | top_right       | position of mute indicator<br>`top_left`, `top_right`, `top_center`. also: `middle_*`, `bottom_*`<br>same as `top_*` (ie: `bottom_right`)  |
 | `mute_icon_size`         | 35              | mute indicator size                                                                                                                        |
+| `seekbar_hide`           | no              | hide indicator when dragging seekbar (requires OSC support)                                                                                |
 
 ### How to install
 

--- a/extras/pause-indicator-lite/pause_indicator_lite.conf
+++ b/extras/pause-indicator-lite/pause_indicator_lite.conf
@@ -61,3 +61,6 @@ mute_indicator_pos=top_right
 
 # mute icon size
 mute_icon_size=50
+
+# hide indicator when dragging seekbar (requires OSC support)
+seekbar_hide=no

--- a/extras/pause-indicator-lite/pause_indicator_lite.lua
+++ b/extras/pause-indicator-lite/pause_indicator_lite.lua
@@ -49,6 +49,9 @@ local options = {
                                           -- also: middle_*, bottom_* same as top_* (ie: bottom_right)
 
     mute_icon_size = 35,                  -- size of the mute speaker icon
+
+    -- seekbar dragging
+    seekbar_hide = false,                 -- hide indicator when dragging seekbar (requires OSC support)
 }
 
 local msg = require "mp.msg"
@@ -69,6 +72,7 @@ local state = {
     toggled = false,
     eof = false,
     keybinds_registered = false,
+    seeking = false,
 }
 
 local icon_theme = {
@@ -261,13 +265,21 @@ local function setup_keybinds()
     state.keybinds_registered = true
 end
 
+if options.seekbar_hide then
+    mp.register_script_message("seekbar-drag", function(val)
+        state.seeking = (val == "start")
+    end)
+end
+
 local pause_observer = function(_, paused)
     state.paused = paused
     if paused then
-        update_indicator()
-        state.toggled = true
         kill_timer("flash_timer")
         state.flash_overlay:remove()
+        if not (options.seekbar_hide and state.seeking) then
+            update_indicator()
+            state.toggled = true
+        end
         if options.keybind_allow and options.keybind_mode == "onpause" then
             if keybind_should_enable() then
                 mp.enable_key_bindings("pause-indicator", "allow-vo-dragging+allow-hide-cursor")
@@ -277,7 +289,7 @@ local pause_observer = function(_, paused)
         kill_timer("indicator_timer")
         state.indicator_overlay:remove()
         state.indicator_visible = false
-        if state.toggled then
+        if state.toggled and not (options.seekbar_hide and state.seeking) then
             update_flash_icon()
             state.toggled = false
         end

--- a/modernz.lua
+++ b/modernz.lua
@@ -3205,6 +3205,7 @@ local function osc_init()
     ne.eventresponder["mouse_move"] = function (element)
         if not element.state.mbtnleft then return end -- allow drag for mbtnleft only!
         state.playing_and_seeking = true
+        mp.commandv("script-message", "seekbar-drag", "start")
         if not mp.get_property_bool("pause") and user_opts.mouse_seek_pause then
             mp.commandv("cycle", "pause")
         end
@@ -3239,6 +3240,7 @@ local function osc_init()
             end
             state.playing_and_seeking = false
         end
+        mp.commandv("script-message", "seekbar-drag", "end")
     end
     ne.eventresponder["mbtn_right_down"] = function (element)
         local chapter


### PR DESCRIPTION
Adds an option to control whether the pause indicator shows up while seeking and `mouse_seek_pause=yes`.