### PR TITLE
feat: add pin, loop, and speed mouse command options

### DIFF
--- a/docs/CONTROLS.md
+++ b/docs/CONTROLS.md
@@ -112,9 +112,10 @@ Below is a list that explains the OSC buttons function depending on how you inte
 
 ### Loop
 
-| Action            | Function                        |
-| ----------------- | ------------------------------- |
-| Left mouse click  | Toggle current file loop on/off |
+| Action             | Function                        |
+| ------------------ | ------------------------------- |
+| Left mouse click   | Toggle current file loop on/off |
+| Right mouse click  | Toggle playlist loop on/off     |
 
 ### Shuffle
 

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -122,8 +122,6 @@ watch-later-options-remove=osd-margin-y
 | loop_button                | yes           | show `file loop` button                                                                                            |
 | shuffle_button             | no            | show `shuffle` button                                                                                              |
 | speed_button               | yes           | show speed control button                                                                                          |
-| speed_button_click         | 1             | speed change amount per click                                                                                      |
-| speed_button_scroll        | 0.25          | speed change amount on scroll                                                                                      |
 | buttons_always_active      | none          | force buttons to always be active. can add: `playlist_prev`, `playlist_next`                                       |
 | info_button                | yes           | show `info (stats)` button                                                                                         |
 | fullscreen_button          | yes           | show `fullscreen toggle` button                                                                                    |
@@ -240,6 +238,8 @@ Customize the button function based on mouse actions.
 | Title (above seekbar)         | title_mbtn_left_command          | `script-binding stats/display-page-5`        |
 |                               | title_mbtn_mid_command           | `show-text ${path}`                          |
 |                               | title_mbtn_right_command         | `script-binding select/select-watch-history` |
+| Chapter title                 | chapter_title_mbtn_left_command  | `script-binding select/select-chapter`       |
+|                               | chapter_title_mbtn_right_command | `show-text ${chapter-list} 3000`             |
 | Playlist button               | playlist_mbtn_left_command       | `script-binding select/select-playlist`      |
 |                               | playlist_mbtn_right_command      | `script-binding select/menu`                 |
 | Volume button                 | vol_ctrl_mbtn_left_command       | `no-osd cycle mute`                          |
@@ -266,8 +266,6 @@ Customize the button function based on mouse actions.
 |                               | chapter_next_mbtn_left_command   | `add chapter 1`                              |
 |                               | chapter_next_mbtn_mid_command    | `show-text ${chapter-list} 3000`             |
 |                               | chapter_next_mbtn_right_command  | `script-binding select/select-chapter`       |
-| Chapter title (below seekbar) | chapter_title_mbtn_left_command  | `script-binding select/select-chapter`       |
-|                               | chapter_title_mbtn_right_command | `show-text ${chapter-list} 3000`             |
 | Playlist skip Buttons         | playlist_prev_mbtn_left_command  | `playlist-prev`                              |
 |                               | playlist_prev_mbtn_mid_command   | `show-text ${playlist} 3000`                 |
 |                               | playlist_prev_mbtn_right_command | `script-binding select/select-playlist`      |
@@ -277,7 +275,14 @@ Customize the button function based on mouse actions.
 | Fullscreen button             | fullscreen_mbtn_left_command     | `cycle fullscreen`                           |
 |                               | fullscreen_mbtn_right_command    | `cycle window-maximized`                     |
 | Info button                   | info_mbtn_left_command           | `script-binding stats/display-page-1-toggle` |
+| Pin (ontop) button            | ontop_mbtn_left_command          | `osd-msg cycle ontop`                        |
 | Screenshot button             | screenshot_mbtn_left_command     | `osd-msg screenshot video`                   |
+| Loop button                   | file_loop_mbtn_left_command      | `osd-msg cycle-values loop-file inf no`      |
+|                               | file_loop_mbtn_right_command     | `osd-msg cycle-values loop-playlist inf no`  |
+| Speed button                  | speed_mbtn_left_command          | `osd-msg add speed 1`                        |
+|                               | speed_mbtn_right_command         | `osd-msg set speed 1`                        |
+|                               | speed_wheel_down_command         | `osd-msg add speed -0.25`                    |
+|                               | speed_wheel_up_command           | `osd-msg add speed 0.25`                     |
 
 ### Auto Profile
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -175,10 +175,6 @@ loop_button=yes
 shuffle_button=no
 # show speed control button
 speed_button=yes
-# speed change amount per click
-speed_button_click=1
-# speed change amount on scroll
-speed_button_scroll=0.25
 # show info button
 info_button=yes
 # show fullscreen toggle button
@@ -424,5 +420,18 @@ fullscreen_mbtn_right_command=cycle window-maximized
 # info button mouse actions
 info_mbtn_left_command=script-binding stats/display-page-1-toggle
 
+# ontop (pin) button mouse actions
+ontop_mbtn_left_command=osd-msg cycle ontop
+
 # screenshot button mouse actions
 screenshot_mbtn_left_command=osd-msg screenshot video
+
+# loop file button mouse actions
+file_loop_mbtn_left_command=osd-msg cycle-values loop-file inf no
+file_loop_mbtn_right_command=osd-msg cycle-values loop-playlist inf no
+
+# speed button mouse actions
+speed_mbtn_left_command=osd-msg add speed 1
+speed_mbtn_right_command=osd-msg set speed 1
+speed_wheel_down_command=osd-msg add speed -0.25
+speed_wheel_up_command=osd-msg add speed 0.25

--- a/modernz.conf
+++ b/modernz.conf
@@ -361,6 +361,10 @@ title_mbtn_left_command=script-binding stats/display-page-5
 title_mbtn_mid_command=show-text ${path}
 title_mbtn_right_command=script-binding select/select-watch-history
 
+# chapter title mouse actions
+chapter_title_mbtn_left_command=script-binding select/select-chapter
+chapter_title_mbtn_right_command=show-text ${chapter-list} 3000
+
 # playlist button mouse actions
 playlist_mbtn_left_command=script-binding select/select-playlist
 playlist_mbtn_right_command=script-binding select/menu
@@ -399,10 +403,6 @@ chapter_prev_mbtn_right_command=script-binding select/select-chapter
 chapter_next_mbtn_left_command=add chapter 1
 chapter_next_mbtn_mid_command=show-text ${chapter-list} 3000
 chapter_next_mbtn_right_command=script-binding select/select-chapter
-
-# chapter title (below seekbar) mouse actions
-chapter_title_mbtn_left_command=script-binding select/select-chapter
-chapter_title_mbtn_right_command=show-text ${chapter-list} 3000
 
 # playlist skip buttons mouse actions
 playlist_prev_mbtn_left_command=playlist-prev

--- a/modernz.lua
+++ b/modernz.lua
@@ -118,8 +118,6 @@ local user_opts = {
     loop_button = true,                    -- show file loop button
     shuffle_button = false,                -- show shuffle button
     speed_button = true,                   -- show speed control button
-    speed_button_click = 1,                -- speed change amount per click
-    speed_button_scroll = 0.25,            -- speed change amount on scroll
 
     buttons_always_active = "none",        -- force buttons to always be active. can add: playlist_prev, playlist_next
 
@@ -283,8 +281,21 @@ local user_opts = {
     -- info button mouse actions
     info_mbtn_left_command = "script-binding stats/display-page-1-toggle",
 
+    -- ontop (pin) button mouse actions
+    ontop_mbtn_left_command = "osd-msg cycle ontop",
+
     -- screenshot button mouse actions
     screenshot_mbtn_left_command = "osd-msg screenshot video",
+
+    -- loop file button mouse actions
+    file_loop_mbtn_left_command = "osd-msg cycle-values loop-file inf no",
+    file_loop_mbtn_right_command = "osd-msg cycle-values loop-playlist inf no",
+
+    -- speed button mouse actions
+    speed_mbtn_left_command = "osd-msg add speed 1",
+    speed_mbtn_right_command = "osd-msg set speed 1",
+    speed_wheel_down_command = "osd-msg add speed -0.25",
+    speed_wheel_up_command = "osd-msg add speed 0.25",
 }
 
 local osc_param = {                  -- calculated by osc_init()
@@ -1915,11 +1926,11 @@ end
 local function download_done(success, result, error)
     if success then
         local download_path = mp.command_native({"expand-path", user_opts.download_path})
-        mp.commandv("show-text", "Download saved to " .. download_path)
+        mp.commandv("show-text", "Download saved to " .. download_path, "-1", "1")
         state.downloaded_once = true
         msg.info("Download completed")
     else
-        mp.commandv("show-text", "Download failed - " .. (error or "Unknown error"))
+        mp.commandv("show-text", "Download failed - " .. (error or "Unknown error"), "-1", "1")
         msg.info("Download failed")
     end
     state.downloading = false
@@ -3125,10 +3136,7 @@ local function osc_init()
         if user_opts.ontop_in_topbar and window_controls_enabled() and state.ontop then return nil end
         return state.ontop and locale.ontop_disable or locale.ontop
     end
-    ne.eventresponder["mbtn_left_up"] = function ()
-        mp.commandv("no-osd", "cycle", "ontop")
-        mp.commandv("show-text", state.ontop and locale.ontop_disable or locale.ontop)
-    end
+    bind_buttons("ontop")
 
     --screenshot
     ne = new_element("screenshot", "button")
@@ -3140,37 +3148,23 @@ local function osc_init()
     ne = new_element("file_loop", "button")
     ne.content = function() return state.file_loop and icons.loop_on or icons.loop_off end
     ne.tooltipF = function() return state.file_loop and locale.file_loop_enable or locale.file_loop_disable end
-    ne.eventresponder["mbtn_left_up"] = function ()
-        mp.commandv("show-text", state.file_loop and locale.file_loop_disable or locale.file_loop_enable)
-        state.file_loop = not state.file_loop
-        mp.set_property_native("loop-file", state.file_loop)
-    end
+    bind_buttons("file_loop")
 
     --shuffle
     ne = new_element("shuffle", "button")
     ne.content = function() return state.shuffled and icons.shuffle_on or icons.shuffle_off end
     ne.tooltipF = function() return state.shuffled and locale.shuffle or locale.unshuffle end
     ne.eventresponder["mbtn_left_up"] = function()
-        mp.commandv("show-text", state.shuffled and locale.unshuffle or locale.shuffle)
+        mp.commandv("show-text", state.shuffled and locale.unshuffle or locale.shuffle, "-1", "1")
         state.shuffled = not state.shuffled
         mp.command("playlist-" .. (state.shuffled and "shuffle" or "unshuffle"))
     end
 
     --speed
-    local function adjust_speed(delta)
-        local new_speed = state.speed + delta
-        mp.commandv("set", "speed", math.max(0.25, math.min(100, new_speed)))
-    end
     ne = new_element("speed", "button")
-    ne.content = function()
-        local speed = state.speed
-        return string.format(speed % 1 == 0 and "%.1f×" or "%g×", speed)
-    end
+    ne.content = function() return string.format(state.speed % 1 == 0 and "%.1f×" or "%g×", state.speed) end
     ne.tooltipF = locale.speed_control
-    ne.eventresponder["mbtn_left_up"] = function() adjust_speed(user_opts.speed_button_click) end
-    ne.eventresponder["mbtn_right_up"] = function() mp.commandv("set", "speed", 1) end
-    ne.eventresponder["wheel_up_press"] = function() adjust_speed(user_opts.speed_button_scroll) end
-    ne.eventresponder["wheel_down_press"] = function() adjust_speed(-user_opts.speed_button_scroll) end
+    bind_buttons("speed")
 
     --download
     ne = new_element("download", "button")
@@ -3180,11 +3174,11 @@ local function osc_init()
         local localpath = mp.command_native({"expand-path", user_opts.download_path})
 
         if state.downloaded_once then
-            mp.commandv("show-text", locale.downloaded)
+            mp.commandv("show-text", locale.downloaded, "-1", "1")
         elseif state.downloading then
-            mp.commandv("show-text", locale.download_in_progress)
+            mp.commandv("show-text", locale.download_in_progress, "-1", "1")
         else
-            mp.commandv("show-text", locale.downloading .. "...")
+            mp.commandv("show-text", locale.downloading .. "...", "-1", "1")
             state.downloading = true
             local command = {
                 "yt-dlp",

--- a/modernz.lua
+++ b/modernz.lua
@@ -222,6 +222,10 @@ local user_opts = {
     title_mbtn_mid_command = "show-text ${path}",
     title_mbtn_right_command = "script-binding select/select-watch-history",
 
+    -- chapter title mouse actions
+    chapter_title_mbtn_left_command = "script-binding select/select-chapter",
+    chapter_title_mbtn_right_command = "show-text ${chapter-list} 3000",
+
     -- playlist button mouse actions
     playlist_mbtn_left_command = "script-binding select/select-playlist",
     playlist_mbtn_right_command = "script-binding select/menu",
@@ -260,10 +264,6 @@ local user_opts = {
     chapter_next_mbtn_left_command = "add chapter 1",
     chapter_next_mbtn_mid_command = "show-text ${chapter-list} 3000",
     chapter_next_mbtn_right_command = "script-binding select/select-chapter",
-
-    -- chapter title (below seekbar) mouse actions
-    chapter_title_mbtn_left_command = "script-binding select/select-chapter",
-    chapter_title_mbtn_right_command = "show-text ${chapter-list} 3000",
 
     -- playlist skip buttons mouse actions
     playlist_prev_mbtn_left_command = "playlist-prev",


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/672

### Changes:
- Add pin (ontop), loop, and speed mouse command options
- Right click on loop button will now toggle playlist loop
- Remove `speed_button_click` option
- Remove `speed_button_scroll` option
- Respect `--osd-level` when `show-text` is used internally

### New `modernz.conf` options:

```EditorConfig
# ontop (pin) button mouse actions
ontop_mbtn_left_command=osd-msg cycle ontop

# loop file button mouse actions
file_loop_mbtn_left_command=osd-msg cycle-values loop-file inf no
file_loop_mbtn_right_command=osd-msg cycle-values loop-playlist inf no

# speed button mouse actions
speed_mbtn_left_command=osd-msg add speed 1
speed_mbtn_right_command=osd-msg set speed 1
speed_wheel_down_command=osd-msg add speed -0.25
speed_wheel_up_command=osd-msg add speed 0.25
```