### PR TITLE
feat: add play_pause left click command

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -258,7 +258,8 @@ Customize the button function based on mouse actions.
 |                               | sub_track_mbtn_right_command     | `cycle sub`                                  |
 |                               | sub_track_wheel_down_command     | `cycle sub`                                  |
 |                               | sub_track_wheel_up_command       | `cycle sub down`                             |
-| Play/Pause button             | play_pause_mbtn_mid_command      | `cycle-values loop-playlist inf no`          |
+| Play/Pause button             | play_pause_mbtn_left_command     | `cycle pause`                                |
+|                               | play_pause_mbtn_mid_command      | `cycle-values loop-playlist inf no`          |
 |                               | play_pause_mbtn_right_command    | `cycle-values loop-file inf no`              |
 | Chapter skip buttons          | chapter_prev_mbtn_left_command   | `add chapter -1`                             |
 |                               | chapter_prev_mbtn_mid_command    | `show-text ${chapter-list} 3000`             |

--- a/modernz.conf
+++ b/modernz.conf
@@ -392,6 +392,7 @@ sub_track_wheel_down_command=cycle sub
 sub_track_wheel_up_command=cycle sub down
 
 # play/pause button mouse actions
+play_pause_mbtn_left_command=cycle pause
 play_pause_mbtn_mid_command=cycle-values loop-playlist inf no
 play_pause_mbtn_right_command=cycle-values loop-file inf no
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -253,6 +253,7 @@ local user_opts = {
     sub_track_wheel_up_command = "cycle sub down",
 
     -- play/pause button mouse actions
+    play_pause_mbtn_left_command = "cycle pause",
     play_pause_mbtn_mid_command = "cycle-values loop-playlist inf no",
     play_pause_mbtn_right_command = "cycle-values loop-file inf no",
 
@@ -2962,15 +2963,15 @@ local function osc_init()
     --play_pause
     ne = new_element("play_pause", "button")
     ne.content = function () return state.eof_reached and icons.replay or (state.pause and not state.playing_and_seeking and icons.play) or icons.pause end
+    bind_buttons("play_pause")
     ne.eventresponder["mbtn_left_up"] = function ()
         if state.eof_reached then
             mp.commandv("seek", 0, "absolute-percent")
             mp.commandv("set", "pause", "no")
         else
-            mp.commandv("cycle", "pause")
+            mp.command(user_opts.play_pause_mbtn_left_command)
         end
     end
-    bind_buttons("play_pause")
 
     local jump_amount = user_opts.jump_amount
     local jump_more_amount = user_opts.jump_more_amount


### PR DESCRIPTION
Makes left click customizable during regular playback to match upstream mpv.

This PR would allow adding extra things on user's side; for example a script message to show a pause indicator:

```editorconfig
play_pause_mbtn_left_command=script-message toggle-pause-indicator; cycle pause
```
For more context, in my setup I try to avoid showing an indicator when seeking or frame stepping etc so I rely on this script message to show it in specific ways.