### PR TITLE
pause-indicator: show indicator if starting paused

### DIFF
--- a/extras/pause-indicator-lite/pause_indicator_lite.lua
+++ b/extras/pause-indicator-lite/pause_indicator_lite.lua
@@ -290,7 +290,10 @@ end
 local dimensions_observer = function()
     local _, _, aspect = mp.get_osd_size()
     state.aspect = aspect
-    if state.indicator_visible then
+    if state.paused and not state.indicator_visible then
+        update_indicator(true)
+        state.toggled = true
+    elseif state.indicator_visible then
         update_indicator(true)
     end
     if state.mute_visible then


### PR DESCRIPTION
If watch-later restores a paused state, the pause_observer may fire before osd-dimensions is ready, causing update_indicator to bail out.

**Testing:**
1. `watch-later-options=pause` in `mpv.conf`
2. Pause some video
3. Do `quit-watch-later`
4. Open the same file again