### PR TITLE
feat: add URL decoding for media titles

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -2873,6 +2873,13 @@ local function osc_init()
 
     local function make_escaped_title(source)
         local title = mp.command_native({"expand-text", source})
+        -- Decode URL title (%XX code)
+        if state.is_URL then
+            title = title:gsub("+", " ")
+            title = title:gsub("%%(%x%x)", function(h)
+                return string.char(tonumber(h, 16))
+            end)
+        end
         title = title:gsub("\n", " ")
         return title ~= "" and mp.command_native({"escape-ass", title}) or "mpv"
     end


### PR DESCRIPTION
This PR fixes the issue where web streams without metadata display raw URL characters (like `%20` instead of spaces) in the OSC title.

- Added regex decoding in `make_escaped_title`.
- Wrapped in `if state.is_URL` to ensure local file paths remain completely unaffected.