### PR TITLE
docs: add open-file.lua details for adding a subtitle

### DIFF
--- a/docs/INTERACTIVE_MENUS.md
+++ b/docs/INTERACTIVE_MENUS.md
@@ -79,23 +79,29 @@ You can add or remove any of the list items to suit your needs. [[full list of M
 ```
 
 ### Open File Dialog (Optional)
-The solution below only works for Windows, however you can search for one that works for your operating system in [mpv user scripts](https://github.com/mpv-player/mpv/wiki/User-Scripts) or [awesome-mpv](https://github.com/stax76/awesome-mpv), then apply it the same way.
 
-<img width="1740" height="832" alt="image" src="https://github.com/user-attachments/assets/5f27079d-ceab-4aa2-90ca-36f1194a850a" />
+<img width="2023" height="1123" alt="open-file" src="https://github.com/user-attachments/assets/3b4ffa5f-05bb-420f-99d5-33d8abf2b9e4" /><br>
 
-To be able to open a file directly from mpv, you can use [open-file.lua](https://github.com/Samillion/mpv-conf/blob/master/scripts/open-file.lua) script.
+To be able to open a file or add a subtitle directly from mpv, you can use [open-file.lua](https://github.com/Samillion/mpv-conf/blob/master/scripts/open-file.lua) script.
 
 In your `input.conf`, add:
 ```
-Ctrl+o script-binding open_file/open
+Ctrl+o          script-binding open_file/open
+Ctrl+Shift+s    script-binding open_file/add_subtitle
 ```
 
 In your `menu.conf`, add:
 ```
-&Open File	script-binding open_file/open
+&Open File		script-binding open_file/open
+&Add Subtitle	script-binding open_file/add_subtitle
 ```
 
 You can see how that's done by viewing this [input.conf](https://github.com/Samillion/mpv-conf/blob/master/input.conf) and this [menu.conf](https://github.com/Samillion/mpv-conf/blob/master/menu.conf).
+
+The script `open-file.lua` only works for Windows, however you can search for one that works for your operating system in [mpv user scripts](https://github.com/mpv-player/mpv/wiki/User-Scripts) or [awesome-mpv](https://github.com/stax76/awesome-mpv), then apply it the same way.
+
+- Linux (Gnome): [zenity-open-files.lua](https://github.com/alifarazz/mpv-zenity-open-files/blob/master/zenity-open-files.lua)
+- Linux (KDE): [kdialog-open-files.lua](https://gist.github.com/ntasos/d1d846abd7d25e4e83a78d22ee067a22)
 
 ## Notes
 > [!IMPORTANT]


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/396

Changes:
- Add details about the update for `open-file.lua`, which allows adding subtitles

----

Should `open-file.lua` be added to `/extras`? cc @Keith94 @nekoxuee 

----

### Script Changes

[open-file.lua](https://github.com/Samillion/mpv-conf/blob/master/scripts/open-file.lua)

- Add keybind for adding a subtitle
- Add more media file extensions by default

### Extensions List
Can also choose `Select All`, to view all file types, not just ones from the extensions list.

```
*.mkv;*.mp4;*.avi;*.mov;*.webm;*.wmv;*.gif;*.m4v;*.flv;*.mpg;*.mpeg;*.vob;*.ogv;
*.3gp;*.ts;*.divx;*.mp3;*.flac;*.aac;*.ogg;*.wav;*.m4a;*.opus;*.wma;*.mka;*.m3u;*.m3u8
```

### Usage
The keybinds are just a suggestion, you can set them to whatever you desire.

`input.conf:`
```
Ctrl+o          script-binding open_file/open
Ctrl+Shift+s    script-binding open_file/add_subtitle
```

`menu.conf`:
```
&Open File		script-binding open_file/open
&Add Subtitle	script-binding open_file/add_subtitle
```