### PR TITLE
fix: set seekbarkeyframes in duration observer, not file-loaded event

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -194,7 +194,7 @@ watch-later-options-remove=osd-margin-y
 | seekrange                     | yes      | show seek range overlay                                                 |
 | seekrangealpha                | 150      | transparency of the seek range                                          |
 | livemarkers                   | yes      | update chapter markers on the seekbar when duration changes             |
-| seekbarkeyframes              | no       | use keyframes when dragging the seekbar                                 |
+| seekbarkeyframes              | yes      | use keyframes when dragging the seekbar                                 |
 | slider_rounded_corners        | yes      | rounded corners seekbar slider                                          |
 | nibbles_style                 | gap      | chapter nibble style: `gap`, `triangle`, `bar` or `single-bar`          |
 | nibbles_top                   | yes      | top chapter nibbles above seekbar                                       |

--- a/modernz.conf
+++ b/modernz.conf
@@ -300,7 +300,7 @@ seekrangealpha=150
 # update chapter markers on the seekbar when duration changes
 livemarkers=yes
 # use keyframes when dragging the seekbar
-seekbarkeyframes=no
+seekbarkeyframes=yes
 # rounded corners seekbar slider
 slider_rounded_corners=yes
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -3851,9 +3851,6 @@ mp.register_event("file-loaded", function()
     is_image() -- check if file is an image
     state.file_loaded = true
     check_path_url()
-    if user_opts.automatickeyframemode then
-        user_opts.seekbarkeyframes = (state.duration or 0) > user_opts.automatickeyframelimit
-    end
     local oos = user_opts.osc_on_start
     if oos == "bottom" or oos == "both" then show_osc() end
     if oos == "top" or oos == "both" then show_wc() end
@@ -3868,6 +3865,9 @@ observe_cached("chapter-list", function ()
     request_init()
 end)
 observe_cached("duration", function ()
+    if user_opts.automatickeyframemode then
+        user_opts.seekbarkeyframes = (state.duration or 0) > user_opts.automatickeyframelimit
+    end
     if user_opts.livemarkers and state.chapter_list[1] then
         request_init()
     end

--- a/modernz.lua
+++ b/modernz.lua
@@ -183,7 +183,7 @@ local user_opts = {
     seekrange = true,                      -- show seek range overlay
     seekrangealpha = 150,                  -- transparency of the seek range
     livemarkers = true,                    -- update chapter markers on the seekbar when duration changes
-    seekbarkeyframes = false,              -- use keyframes when dragging the seekbar
+    seekbarkeyframes = true,               -- use keyframes when dragging the seekbar
     slider_rounded_corners = true,         -- rounded corners seekbar slider
 
     nibbles_style = "gap",                 -- chapter nibble style: "gap", "triangle", "bar", or "single-bar"
@@ -3215,6 +3215,9 @@ local function osc_init()
     end
     ne.slider.posF = function ()
         if state.eof_reached then return 100 end
+        if ne.state.mbtnleft then
+            return get_slider_value(ne)
+        end
         return mp.get_property_number("percent-pos")
     end
     ne.slider.tooltipF = function (pos)

--- a/modernz.lua
+++ b/modernz.lua
@@ -3215,9 +3215,6 @@ local function osc_init()
     end
     ne.slider.posF = function ()
         if state.eof_reached then return 100 end
-        if ne.state.mbtnleft then
-            return get_slider_value(ne)
-        end
         return mp.get_property_number("percent-pos")
     end
     ne.slider.tooltipF = function (pos)


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/727

**Changes**:
- Enable `seekbarkeyframes` by default
- Set `seekbarkeyframes` in `duration` observer, not `file-loaded` event