### PR TITLE
fix: prevent duplicate OSC progress bars on mpv >= 0.41

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -13,7 +13,12 @@ local assdraw = require "mp.assdraw"
 local msg = require "mp.msg"
 local opt = require "mp.options"
 local utils = require "mp.utils"
-mp.set_property("osc", "no")
+-- Disable the built-in OSC if not already set in mpv.conf
+-- Avoid redundant property set that can cause mpv >= 0.41 to load the
+-- built-in osc.lua alongside ModernZ, resulting in duplicate progress bars
+if mp.get_property("osc") ~= "no" then
+    mp.set_property("osc", "no")
+end
 
 -- Parameters
 -- default user option values


### PR DESCRIPTION
## Summary

Fixes duplicate/overlapping OSC progress bars when using ModernZ with mpv >= 0.41.0.

## Root Cause

In mpv 0.41.0, calling `mp.set_property("osc", "no")` at script load time can cause the built-in `@osc.lua` to be unexpectedly loaded alongside ModernZ — even when `osc=no` is already set in `mpv.conf`. The built-in OSC and ModernZ OSC both render their seekbar, resulting in two overlapping progress bars.

## Fix

Before calling `mp.set_property("osc", "no")`, check if the osc property is already `"no"` (meaning the user followed the documented setup and added `osc=no` to their `mpv.conf`). If already disabled, skip the redundant call.

```lua
if mp.get_property("osc") ~= "no" then
    mp.set_property("osc", "no")
end
```

This preserves the safety net for users who haven't added `osc=no` in their mpv.conf, while avoiding the problematic redundant property set that triggers the double-loading bug.

## Test Plan

- [x] Verified on macOS with mpv 0.41.0 + ModernZ v0.3.2
- [ ] mpv < 0.41: behavior unchanged (safety net still works)
- [ ] mpv >= 0.41 with `osc=no` in mpv.conf: no duplicate OSC
- [ ] mpv >= 0.41 without `osc=no` in mpv.conf: built-in OSC still disabled by ModernZ

🤖 Generated with [Claude Code](https://claude.com/claude-code)