### PR TITLE
feat: add mini and seekbar layouts and improve existing layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A sleek and modern OSC for [mpv](https://mpv.io/). This project is a fork of ModernX that enhances functionality by adding more features while preserving the core standards of mpv's OSC.
 
-<img width="1715" height="966" alt="ModernZ" src="https://github.com/user-attachments/assets/a2c8081e-2909-4bd1-872d-c59c48e76302" />
+![modernz_preview](https://github.com/user-attachments/assets/69a967ae-cf8a-4a92-9193-4799f901cd94)
 
 <p align="center">
   <a href="#installation"><strong>Installation »</strong></a><br>
@@ -14,10 +14,10 @@ A sleek and modern OSC for [mpv](https://mpv.io/). This project is a fork of Mod
 
 ## Features
 
-- 🎨 Modern, customizable interface with multiple layouts, themes, and icon styles [[options](#configuration)]
-- 🖱️ Independent hover zone for top bar (window controls) and bottom bar (OSC)
+- 🎨 Modern, customizable interface with multiple layouts, themes, and icon styles [[options](#customization)]
+- 🖱️ Independent hover zone for top bar (window controls bar) and bottom bar (OSC)
 - 📷 Image Viewer mode with zoom controls [[details](/docs/IMAGE_VIEWER.md)]
-- 🎛️ Buttons: download, playlist, speed control, screenshot, pin, loop, cache, and more. [[details](/docs/CONTROLS.md)]
+- 🎛️ Buttons: download, playlist, speed control, screenshot, pin, loop, shuffle, and more. [[details](/docs/CONTROLS.md)]
 - 📄 Interactive menus for playlist, subtitles, chapters, audio tracks, and audio devices
 - 🌐 Multi-language support with JSON [locale](#translations) integration
 - ⌨️ Configurable controls [[details](#controls)]
@@ -28,32 +28,56 @@ A sleek and modern OSC for [mpv](https://mpv.io/). This project is a fork of Mod
 </a>
 
 ## Customization
-Choose the layout that suits your preference (`modern` or `modern-compact`) using the `layout` option in your `modernz.conf`.
+ModernZ provides a wide range of customization options, including multiple layouts, themes, icon styles, color adjustments, and much more.
 
 ### Layouts
+Choose the layout that suits your preference using the `layout` option in your `modernz.conf`, which accepts: `default`, `compact`, `mini`, and `seekbar`
 
 <table>
     <thead>
         <tr>
-            <th><code>modern</code></th>
+            <th><code>default</code></th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td><img width="1715" height="120" alt="modernz_modern_layout" src="https://github.com/user-attachments/assets/97791b5b-e7c8-47bc-8805-a286052762f6" /></td>
+            <td><img width="1961" height="125" alt="layout_default" src="https://github.com/user-attachments/assets/afa29219-d3ea-490b-bf34-530a9ba212a4" /></td>
         </tr>
     </tbody>
 </table>
-
 <table>
     <thead>
         <tr>
-            <th><code>modern-compact</code></th>
+            <th><code>compact</code></th>
         </tr>
     </thead>
     <tbody>
         <tr>
-            <td><img width="1715" height="150" alt="modernz_compact_layout" src="https://github.com/user-attachments/assets/b88f7823-b328-427e-8720-c2d4ab2c496a" /></td>
+            <td><img width="1961" height="125" alt="layout_compact" src="https://github.com/user-attachments/assets/f18c4432-32da-48b4-bc93-d50592b4a25b" /></td>
+        </tr>
+    </tbody>
+</table>
+<table>
+    <thead>
+        <tr>
+            <th><code>mini</code></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><img width="1961" height="125" alt="layout_mini" src="https://github.com/user-attachments/assets/a4f5d467-0286-4280-b284-9aaec8e6e42f" /></td>
+        </tr>
+    </tbody>
+</table>
+<table>
+    <thead>
+        <tr>
+            <th><code>seekbar</code></th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><img width="1961" height="124" alt="layout_seekbar" src="https://github.com/user-attachments/assets/4479b9d3-cdfb-4ebb-ac85-8d4c8ba101e1" /></td>
         </tr>
     </tbody>
 </table>
@@ -70,7 +94,7 @@ You can also change the icon theme to `fluent` or `material` to match your prefe
     </thead>
     <tbody>
         <tr>
-            <td><img width="1715" height="120" alt="modernz_fluent_theme" src="https://github.com/user-attachments/assets/9c0172db-f959-4c95-a31f-aab55290f5ec" /></td>
+            <td><img width="1961" height="125" alt="theme_fluent" src="https://github.com/user-attachments/assets/0fb0580c-6389-4427-8f23-e71ac1092aca" /></td>
         </tr>
     </tbody>
 </table>
@@ -83,14 +107,14 @@ You can also change the icon theme to `fluent` or `material` to match your prefe
     </thead>
     <tbody>
         <tr>
-            <td><img width="1715" height="120" alt="modernz_material_theme" src="https://github.com/user-attachments/assets/cc532cd8-32aa-4dba-93eb-5f8f599ea654" /></td>
+            <td><img width="1961" height="125" alt="theme_material" src="https://github.com/user-attachments/assets/95d2ebd6-b87d-4170-8faa-cb7112c3482a" /></td>
         </tr>
     </tbody>
 </table>
 
-### Theme Styles
+### Icon Styles
 
-Both `fluent` and `material` themes have different styles as well. By using the `icon_style` option, you can choose `mixed`, `filled`, or `outline`.
+Both `fluent` and `material` themes have different icon styles as well. By using the `icon_style` option, you can choose `mixed`, `filled`, or `outline`.
 
 <table>
     <thead>
@@ -105,15 +129,15 @@ Both `fluent` and `material` themes have different styles as well. By using the 
     <tbody>
         <tr>
             <td><code>mixed</code></td>
-            <td><img width="1715" height="120" alt="modernz_fluent_mixed" src="https://github.com/user-attachments/assets/58774224-1fd2-4939-8263-b14bba551be0" /></td>
+            <td><img width="1961" height="125" alt="icon_style_fluent_mixed" src="https://github.com/user-attachments/assets/ce59d30d-adcf-4961-b153-4711a7bc12c6" /></td>
         </tr>
         <tr>
             <td><code>filled</code></td>
-            <td><img width="1715" height="120" alt="modernz_fluent_filled" src="https://github.com/user-attachments/assets/c0beee55-b6c8-4bef-a192-0b529c1ecea9" /></td>
+            <td><img width="1961" height="125" alt="icon_style_fluent_filled" src="https://github.com/user-attachments/assets/a5047c68-c8be-43c9-9c5a-c12dbeeb916f" /></td>
         </tr>
         <tr>
             <td><code>outline</code></td>
-            <td><img width="1715" height="120" alt="modernz_fluent_outline" src="https://github.com/user-attachments/assets/5c6af748-1f4e-46e6-b6b9-470954e93ef8" /></td>
+            <td><img width="1961" height="125" alt="icon_style_fluent_outline" src="https://github.com/user-attachments/assets/ce660cf4-b3f9-43a1-af92-fe2175a43bf6" /></td>
         </tr>
     </tbody>
 </table>
@@ -131,22 +155,22 @@ Both `fluent` and `material` themes have different styles as well. By using the 
     <tbody>
         <tr>
             <td><code>mixed</code></td>
-            <td><img width="1715" height="120" alt="modernz_material_mixed" src="https://github.com/user-attachments/assets/2518a9f6-8a07-499c-912d-a527535d6ff1" /></td>
+            <td><img width="1961" height="125" alt="icon_style_material_mixed" src="https://github.com/user-attachments/assets/3fb6730b-3ec2-4ce2-80e8-41faf2aced8c" /></td>
         </tr>
         <tr>
             <td><code>filled</code></td>
-            <td><img width="1715" height="120" alt="modernz_material_filled" src="https://github.com/user-attachments/assets/c14f94f3-0564-4ef8-b46a-6e1edb75556c" /></td>
+            <td><img width="1961" height="125" alt="icon_style_material_filled" src="https://github.com/user-attachments/assets/befe569c-ea72-42b4-a0f0-f189578a0df5" /></td>
         </tr>
         <tr>
             <td><code>outline</code></td>
-            <td><img width="1715" height="120" alt="modernz_material_outline" src="https://github.com/user-attachments/assets/d1e12ff2-a4bb-4956-9049-821fe243ad93" /></td>
+            <td><img width="1961" height="125" alt="icon_style_material_outline" src="https://github.com/user-attachments/assets/8f28b937-d03c-4920-98c4-b69998989626" /></td>
         </tr>
     </tbody>
 </table>
 
 ### Seek Bar
 
-If you find the seek bar too thin or too thick, you can easily adjust its size using the `seekbar_height` option. Available values include `small`, `medium` (default), `large`, and `xlarge`.
+If you find the seek bar too thin or too thick, you can easily adjust its size using the `seekbar_height` option. Available values include `small`, `medium`, `large`, and `xlarge`.
 
 <table>
     <tr>
@@ -154,24 +178,16 @@ If you find the seek bar too thin or too thick, you can easily adjust its size u
         <th><code>medium</code> (Default)</th>
     </tr>
     <tr>
-        <td>
-            <img width="500" height="110" alt="seekbar_small" src="https://github.com/user-attachments/assets/749e6ee9-8964-45bd-841e-8e14510b1805" />
-        </td>
-        <td>
-            <img width="500" height="110" alt="seekbar_medium" src="https://github.com/user-attachments/assets/6ed7aa8f-0f66-436c-bc71-04f5e38d89da" />
-        </td>
+        <td><img width="500" height="125" alt="seekbar_height_small" src="https://github.com/user-attachments/assets/d233d440-9915-4796-8cf7-5c9e85a0b27c" /></td>
+        <td><img width="500" height="125" alt="seekbar_height_medium" src="https://github.com/user-attachments/assets/cbe7d65c-c35b-41c2-a66a-c57c09665e8d" /></td>
     </tr>
     <tr>
         <th><code>large</code></th>
         <th><code>xlarge</code></th>
     </tr>
     <tr>
-        <td>
-            <img width="500" height="110" alt="seekbar_large" src="https://github.com/user-attachments/assets/282ba6a8-d33a-4f10-a431-c90a6245883d" />
-        </td>
-        <td>
-            <img width="500" height="110" alt="seekbar_xlarge" src="https://github.com/user-attachments/assets/49b2cafb-ac82-47fa-b0fb-176fbc1942d5" />
-        </td>
+        <td><img width="500" height="125" alt="seekbar_height_large" src="https://github.com/user-attachments/assets/a2d76a38-b25b-4501-b38c-707db8c5f16f" /></td>
+        <td><img width="500" height="125" alt="seekbar_height_xlarge" src="https://github.com/user-attachments/assets/1542a3aa-e905-4c8a-a797-ee8841b33ca2" /></td>
     </tr>
 </table>
 
@@ -184,24 +200,16 @@ You can change the chapter markers style by using the `nibbles_style` option, wh
         <th><code>triangle</code></th>
     </tr>
     <tr>
-        <td>
-            <img width="500" height="110" alt="chapter_gap" src="https://github.com/user-attachments/assets/c89cf611-36ec-4668-86ca-c4b4ebd73122" />
-        </td>
-        <td>
-            <img width="500" height="110" alt="chapter_triangle" src="https://github.com/user-attachments/assets/2cfc504e-086c-4392-bab9-aff90b0fac0c" />
-        </td>
+        <td><img width="550" height="125" alt="chapter_marker_gap" src="https://github.com/user-attachments/assets/27d8e320-8df9-4f70-80a0-23f1e9116ac7" /></td>
+        <td><img width="550" height="125" alt="chapter_marker_triangle" src="https://github.com/user-attachments/assets/cc8774b6-3271-496c-909b-b662c01f9ebb" /></td>
     </tr>
     <tr>
         <th><code>bar</code></th>
         <th><code>single-bar</code></th>
     </tr>
     <tr>
-        <td>
-            <img width="500" height="110" alt="chapter_bar" src="https://github.com/user-attachments/assets/b609661d-8ec3-4146-ba3c-853dc802e64f" />
-        </td>
-        <td>
-            <img width="500" height="110" alt="chapter_singlebar" src="https://github.com/user-attachments/assets/03696a4c-8dc5-44f6-8090-b27e01562526" />
-        </td>
+        <td><img width="550" height="125" alt="chapter_marker_bar" src="https://github.com/user-attachments/assets/1674d5fe-0aa7-4240-9b14-56077852b2ce" /></td>
+        <td><img width="550" height="125" alt="chapter_marker_singlebar" src="https://github.com/user-attachments/assets/ef57c568-8421-48db-9dab-6f3bbb18da11" /></td>
     </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Choose the layout that suits your preference using the `layout` option in your `
     </thead>
     <tbody>
         <tr>
-            <td><img width="1961" height="125" alt="layout_compact" src="https://github.com/user-attachments/assets/f18c4432-32da-48b4-bc93-d50592b4a25b" /></td>
+            <td><img width="1961" height="125" alt="layout_compact" src="https://github.com/user-attachments/assets/6a51fd86-5ed0-4162-9991-8edad2250221" /></td>
         </tr>
     </tbody>
 </table>

--- a/docs/INTERACTIVE_MENUS.md
+++ b/docs/INTERACTIVE_MENUS.md
@@ -1,6 +1,6 @@
 ## Interactive Menus
 
-https://github.com/user-attachments/assets/43b92663-d69a-4549-87cd-e60cff89d395
+https://github.com/user-attachments/assets/51a3549a-7944-48b3-899f-f3a03a8caeaf
 
 ModernZ integrates mpv’s built-in [`console.lua`](https://github.com/mpv-player/mpv/blob/master/player/lua/console.lua) and [`select.lua`](https://github.com/mpv-player/mpv/blob/master/player/lua/select.lua) scripts, available in mpv starting from **v0.39+**.
 
@@ -29,14 +29,16 @@ To enable context-menu:
 
 #### Context menu list for ModernZ in `menu.conf`:
 
-You can add or remove any of the list items to suit your needs. [[full list of ModernZ options](/docs/USER_OPTS.md)]
+You can add or adjust any of the list items to suit your needs from the [[list of ModernZ options](/docs/USER_OPTS.md)] in the context menu.
 
 ```
 
-&ModernZ
+&ModernZ			disabled=idle_active
 	&Layout
-		&Modern				no-osd change-list script-opts append modernz-layout=modern
-		Modern &Compact		no-osd change-list script-opts append modernz-layout=modern-compact
+		&Default	no-osd change-list script-opts append modernz-layout=default
+		&Compact	no-osd change-list script-opts append modernz-layout=compact
+		&Mini		no-osd change-list script-opts append modernz-layout=mini
+		&Seekbar	no-osd change-list script-opts append modernz-layout=seekbar
 	&Theme
 		&Icon Theme
             &Fluent		no-osd change-list script-opts append modernz-icon_theme=fluent

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -15,7 +15,7 @@ Create `modernz.conf` in your mpv script-opts directory:
 | Option                    | Value           | Description                                                                                                                    |
 | ------------------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | language                  | default         | set language (for available options, see: [Translations](https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md)) |
-| layout                    | modern          | set layout: `"modern"` or `"modern-compact"`                                                                                   |
+| layout                    | default         | set layout: `default`, `compact`, `mini`, `seekbar`                                                                            |
 | icon_theme                | fluent          | set icon theme. accepts `fluent` or `material`                                                                                 |
 | icon_style                | mixed           | "mixed", "filled", "outline"                                                                                                   |
 | font                      | mpv-osd-symbols | font for the OSC (default: mpv-osd-symbols or the one set in mpv.conf)                                                         |

--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -113,17 +113,17 @@ watch-later-options-remove=osd-margin-y
 | playlist_button            | yes           | show playlist button: Left-click for simple playlist, Right-click for interactive playlist                         |
 | hide_empty_playlist_button | no            | hide playlist button when no playlist exists                                                                       |
 | gray_empty_playlist_button | no            | gray out the playlist button when no playlist exists                                                               |
-| download_button            | yes           | show download button on web videos (requires yt-dlp and ffmpeg)                                                    |
-| download_path              | ~~desktop/mpv | default download directory for videos. [Learn more about setting paths here](https://mpv.io/manual/master/#paths). |
-| screenshot_button          | yes           | show screenshot button                                                                                             |
+| fullscreen_button          | yes           | show `fullscreen toggle` button                                                                                    |
+| info_button                | yes           | show `info (stats)` button                                                                                         |
 | ontop_button               | yes           | show `window on top (pin)` button                                                                                  |
 | ontop_in_topbar            | no            | move ontop button to top bar when ontop is active                                                                  |
+| screenshot_button          | yes           | show screenshot button                                                                                             |
+| download_button            | yes           | show download button on web videos (requires yt-dlp and ffmpeg)                                                    |
+| download_path              | ~~desktop/mpv | default download directory for videos. [Learn more about setting paths here](https://mpv.io/manual/master/#paths). |
 | loop_button                | yes           | show `file loop` button                                                                                            |
 | shuffle_button             | no            | show `shuffle` button                                                                                              |
 | speed_button               | yes           | show speed control button                                                                                          |
 | buttons_always_active      | none          | force buttons to always be active. can add: `playlist_prev`, `playlist_next`                                       |
-| info_button                | yes           | show `info (stats)` button                                                                                         |
-| fullscreen_button          | yes           | show `fullscreen toggle` button                                                                                    |
 | playpause_size             | 28            | icon size for the play/pause button                                                                                |
 | midbuttons_size            | 24            | icon size for the middle buttons                                                                                   |
 | sidebuttons_size           | 24            | icon size for the side buttons                                                                                     |
@@ -173,37 +173,37 @@ watch-later-options-remove=osd-margin-y
 
 ### Button interaction settings
 
-| Option                | Value               | Description                                                                                               |
-| -------------------   | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| hover_effect          | size,glow,color,box | active button hover effects: `"glow"`, `"size"`, `"color"`, `"box"`; can use multiple separated by commas |
-| button_hover_size     | 115                 | relative size of a hovered button if "size" effect is active                                              |
-| button_held_size      | 100                 | relative size of a button when held/pressed. below 100 shrinks button when held down                      |
-| button_held_box_alpha | 18                  | alpha of the hover background box when a button is held down                                              |
-| button_glow_amount    | 5                   | glow intensity when `"glow"` hover effect is active                                                       |
-| slider_hover_size     | 100                 | relative size of a hovered slider handle (100 = no size change)                                           |
-| tooltip_hints         | yes                 | enable tooltips for most buttons. seek and volume tooltips are always enabled                             |
+| Option                | Value               | Description                                                                                       |
+| -------------------   | ------------------- | ------------------------------------------------------------------------------------------------- |
+| hover_effect          | size,glow,color,box | active button hover effects: `glow`, `size`, `color`, `box`; can use multiple separated by commas |
+| button_hover_size     | 115                 | relative size of a hovered button if "size" effect is active                                      |
+| button_held_size      | 100                 | relative size of a button when held/pressed. below 100 shrinks button when held down              |
+| button_held_box_alpha | 18                  | alpha of the hover background box when a button is held down                                      |
+| button_glow_amount    | 5                   | glow intensity when `"glow"` hover effect is active                                               |
+| slider_hover_size     | 100                 | relative size of a hovered slider handle (100 = no size change)                                   |
+| tooltip_hints         | yes                 | enable tooltips for most buttons. seek and volume tooltips are always enabled                     |
 
 ### Progress bar settings
 
-| Option                        | Value    | Description                                                             |
-| --------------------------    | -------- | ----------------------------------------------------------------------- |
-| seek_handle_size              | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                         |
-| seek_handle_border_size       | 0.42     | border thickness as a fraction of the handle radius                     |
-| seek_handle_border_hover_size | 0.31     | border thickness when handle is hovered                                 |
-| seekbar_height                | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`             |
-| seekrange                     | yes      | show seek range overlay                                                 |
-| seekrangealpha                | 150      | transparency of the seek range                                          |
-| livemarkers                   | yes      | update chapter markers on the seekbar when duration changes             |
-| seekbarkeyframes              | yes      | use keyframes when dragging the seekbar                                 |
-| slider_rounded_corners        | yes      | rounded corners seekbar slider                                          |
-| nibbles_style                 | gap      | chapter nibble style: `gap`, `triangle`, `bar` or `single-bar`          |
-| nibbles_top                   | yes      | top chapter nibbles above seekbar                                       |
-| nibbles_bottom                | yes      | bottom chapter nibbles below seekbar                                    |
-| automatickeyframemode         | yes      | automatically set keyframes for the seekbar based on video length       |
-| automatickeyframelimit        | 600      | videos longer than this (in seconds) will have keyframes on the seekbar |
-| persistent_progress           | no       | always show a small progress line at the bottom of the screen           |
-| persistent_progress_height    | 17       | height of the persistent progress bar                                   |
-| persistent_buffer             | no       | show cached buffer status in the persistent progress line               |
+| Option                        | Value    | Description                                                                                 |
+| --------------------------    | -------- | ------------------------------------------------------------------------------------------- |
+| seek_handle_size              | 0.8      | size ratio of the seekbar handle (range: 0 ~ 1)                                             |
+| seek_handle_border_size       | 0.42     | border thickness as a fraction of the handle radius                                         |
+| seek_handle_border_hover_size | 0.31     | border thickness when handle is hovered (set equal to `seek_handle_border_size` to disable) |
+| seekbar_height                | medium   | seekbar height preset: `small`, `medium`, `large`, `xlarge`                                 |
+| seekrange                     | yes      | show seek range overlay                                                                     |
+| seekrangealpha                | 150      | transparency of the seek range                                                              |
+| livemarkers                   | yes      | update chapter markers on the seekbar when duration changes                                 |
+| seekbarkeyframes              | yes      | use keyframes when dragging the seekbar                                                     |
+| slider_rounded_corners        | yes      | rounded corners seekbar slider                                                              |
+| nibbles_style                 | gap      | chapter nibble style: `gap`, `triangle`, `bar` or `single-bar`                              |
+| nibbles_top                   | yes      | top chapter nibbles above seekbar                                                           |
+| nibbles_bottom                | yes      | bottom chapter nibbles below seekbar                                                        |
+| automatickeyframemode         | yes      | automatically set keyframes for the seekbar based on video length                           |
+| automatickeyframelimit        | 600      | videos longer than this (in seconds) will have keyframes on the seekbar                     |
+| persistent_progress           | no       | always show a small progress line at the bottom of the screen                               |
+| persistent_progress_height    | 17       | height of the persistent progress bar                                                       |
+| persistent_buffer             | no       | show cached buffer status in the persistent progress line                                   |
 
 ### Miscellaneous settings
 

--- a/modernz.conf
+++ b/modernz.conf
@@ -75,7 +75,7 @@ cache_info_speed=no
 # font size of the cache information
 cache_info_font_size=12
 
-# show chapter title alongside timestamp (below seekbar)
+# show chapter title
 show_chapter_title=yes
 # show chapter above title
 chapter_above_title=no
@@ -156,27 +156,28 @@ hide_empty_playlist_button=no
 # gray out the playlist button when no playlist exists
 gray_empty_playlist_button=no
 
-# show download button on web videos (requires yt-dlp and ffmpeg)
-download_button=yes
-# default download directory for videos (https://mpv.io/manual/master/#paths)
-download_path=~~desktop/mpv
-# show screenshot button
-screenshot_button=yes
-
+# show fullscreen toggle button
+fullscreen_button=yes
+# show info button
+info_button=yes
 # show window on top button
 ontop_button=yes
 # move ontop button to top bar when ontop is active
 ontop_in_topbar=no
+# show screenshot button
+screenshot_button=yes
+
+# show download button on web videos (requires yt-dlp and ffmpeg)
+download_button=yes
+# default download directory for videos (https://mpv.io/manual/master/#paths)
+download_path=~~desktop/mpv
+
 # show file loop button
 loop_button=yes
 # show shuffle button
 shuffle_button=no
 # show speed control button
 speed_button=yes
-# show info button
-info_button=yes
-# show fullscreen toggle button
-fullscreen_button=yes
 
 # force buttons to always be active. can add: playlist_prev,playlist_next
 buttons_always_active=none
@@ -226,7 +227,7 @@ seek_handle_border_color=#FF8232
 volumebar_match_seek_color=no
 # color of the timestamps (below seekbar)
 time_color=#FFFFFF
-# color of the chapter title next to timestamp (below seekbar)
+# color of the chapter title
 chapter_title_color=#FFFFFF
 # color of the side buttons (audio, subtitles, playlist, etc.)
 side_buttons_color=#FFFFFF
@@ -269,8 +270,8 @@ thumbnail_box_radius=4
 thumbnail_box_outline_size=1
 
 # Button interaction settings
-# active button hover effects: "glow", "size", "color"; can use multiple separated by commas
-hover_effect=size,glow,color
+# active button hover effects: glow, size, color, box; can use multiple separated by commas
+hover_effect=size,glow,color,box
 # relative size of a hovered button if "size" effect is active
 button_hover_size=115
 # relative size of a button when held/pressed. below 100 shrinks button when held down
@@ -289,7 +290,7 @@ tooltip_hints=yes
 seek_handle_size=0.8
 # border thickness as a fraction of the handle radius
 seek_handle_border_size=0.42
-# border thickness when handle is hovered
+# border thickness when handle is hovered (set equal to seek_handle_border_size to disable)
 seek_handle_border_hover_size=0.31
 # seekbar height preset: small, medium, large, xlarge
 seekbar_height=medium

--- a/modernz.conf
+++ b/modernz.conf
@@ -1,8 +1,8 @@
 # Language and display
 # set language (for available options, see: https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md)
 language=default
-# set layout: "modern" or "modern-compact"
-layout=modern
+# set layout: default, compact, mini, seekbar
+layout=default
 # set icon theme. accepts fluent or material
 icon_theme=fluent
 # set icon style. accepts mixed, filled, outline

--- a/modernz.lua
+++ b/modernz.lua
@@ -2142,7 +2142,15 @@ layouts["default"] = function ()
 
     if title_and_chapter_h_with_offset == 0 then
         -- add some top padding if both title and chapter aren't displayed
-        title_and_chapter_h_with_offset = user_opts.osc_height * 0.2
+        local ch_skip = user_opts.chapter_skip_buttons and type(state.chapter_list) == "table" and next(state.chapter_list)
+        local outer = (ch_skip and 0 or 100) + (user_opts.jump_buttons and 0 or 100)
+        local timecodes_above = osc_param.playresx < (user_opts.portrait_window_trigger - outer
+            - (user_opts.playlist_button and (not user_opts.hide_empty_playlist_button or state.playlist_count > 1) and 0 or 100)
+            - (state.sub_track_count > 0 and 0 or 100)
+            - (state.audio_track_count > 0 and 0 or 100))
+        title_and_chapter_h_with_offset = timecodes_above
+            and math.max(user_opts.osc_height * 0.2, user_opts.time_codes_offset + user_opts.title_offset + user_opts.time_font_size)
+            or user_opts.osc_height * 0.2
     end
 
     local osc_geo = {
@@ -2213,7 +2221,7 @@ layouts["default"] = function ()
     local playlist_button = user_opts.playlist_button and (not user_opts.hide_empty_playlist_button or state.playlist_count > 1)
 
     local offset = user_opts.jump_buttons and 60 or 0
-    local outeroffset = (chapter_skip_buttons and 0 or 120) + (user_opts.jump_buttons and 0 or 120)
+    local outeroffset = (chapter_skip_buttons and 0 or 100) + (user_opts.jump_buttons and 0 or 100)
 
     local time_codes_width = get_time_codes_width()
     local chapter_title_y, title_y
@@ -2226,8 +2234,10 @@ layouts["default"] = function ()
     end
 
     -- osc title
+    local title_w = (no_chapter or not chapter_index or user_opts.chapter_above_title) and (osc_geo.w - 60 - time_codes_width) or (osc_geo.w - 50)
+    if title_w < 0 then title_w = 0 end
     elements["title"].visible = not no_title
-    geo = {x = 25, y = refY - title_y, an = 1, w = osc_geo.w - 50, h = user_opts.title_font_size}
+    geo = {x = 25, y = refY - title_y, an = 1, w = title_w, h = user_opts.title_font_size}
     lo = add_layout("title")
     lo.geometry = geo
     lo.layer = 48
@@ -2237,7 +2247,7 @@ layouts["default"] = function ()
     -- chapter title
     if user_opts.show_chapter_title then
         elements["chapter_title"].visible = not no_chapter and chapter_index
-        geo = {x = 26, y = refY - chapter_title_y, an = 1, w = osc_geo.w - 60, h = user_opts.chapter_title_font_size}
+        geo = {x = 26, y = refY - chapter_title_y, an = 1, w = osc_geo.w - time_codes_width - 60, h = user_opts.chapter_title_font_size}
         lo = add_layout("chapter_title")
         lo.geometry = geo
         lo.layer = 48
@@ -2259,12 +2269,12 @@ layouts["default"] = function ()
     end
 
     if playlist_button then left_side_button("playlist", 550) end
-    if audio_track and user_opts.audio_tracks_button then left_side_button("audio_track", 800) end
-    if subtitle_track and user_opts.subtitles_button then left_side_button("sub_track", 800) end
+    if audio_track and user_opts.audio_tracks_button then left_side_button("audio_track", 650) end
+    if subtitle_track and user_opts.subtitles_button then left_side_button("sub_track", 750) end
 
     if audio_track and user_opts.volume_control then
         -- volume button
-        left_side_button("vol_ctrl", 900)
+        left_side_button("vol_ctrl", 850)
         start_x = start_x - 25 -- vol_ctrl uses a narrower step (+20 not +45)
 
         -- volume bar
@@ -2291,61 +2301,82 @@ layouts["default"] = function ()
         local vc_left = start_x - 107
         local osc_mid = refY - (user_opts.osc_height / 2)
         elements["vol_ctrl"].hover_box = vol_vis and {x1 = vc_left, y1 = osc_mid - 12, x2 = vc_left + 87, y2 = osc_mid + 12} or nil
-        start_x = vol_vis and start_x or start_x - 75
     end
 
     -- time codes
-    local time_codes_width = get_time_codes_width()
+    local auto_hide_volbar = (audio_track and user_opts.volume_control) and osc_param.playresx < (user_opts.hide_volume_bar_trigger - outeroffset)
+    local time_codes_x = start_x
+        - (auto_hide_volbar and 67 or 0) -- window width with audio track and elements
+        - (audio_track and not user_opts.volume_control and 12 or 0) -- audio track with no elements
+        - (not audio_track and 12 or 0) -- remove excess space
+    local time_codes_y = user_opts.time_codes_offset + (user_opts.osc_height / 2)
+    local narrow_win = osc_param.playresx < (
+        user_opts.portrait_window_trigger
+        - outeroffset
+        - (playlist_button and 0 or 100)
+        - (subtitle_track and 0 or 100)
+        - (audio_track and 0 or 100)
+    )
+    if narrow_win then
+        -- try to vertically align time codes to the baseline of title/chapter
+        if not user_opts.show_title and not user_opts.show_chapter_title then
+            time_codes_y = user_opts.time_codes_offset + user_opts.osc_height + user_opts.title_offset
+        elseif no_chapter or not chapter_index or user_opts.chapter_above_title then
+            time_codes_y = title_y + ((title_h - user_opts.time_font_size) * 0.25)
+        else
+            time_codes_y = chapter_title_y
+            if chapter_h ~= user_opts.time_font_size then
+                time_codes_y = time_codes_y - ((user_opts.time_font_size - chapter_h) * 0.25)
+            end
+        end
+    end
     elements["time_codes"].visible = (state.duration or 0) > 0
     lo = add_layout("time_codes")
-    lo.geometry = {x = start_x + 5, y = refY - (user_opts.osc_height / 2), an = 4, w = time_codes_width, h = user_opts.time_font_size}
+    lo.geometry = {x = (narrow_win and (osc_geo.w - 25) or time_codes_x), y = refY - time_codes_y, an = (narrow_win and 3 or 4), w = time_codes_width, h = user_opts.time_font_size}
     lo.layer = 48
     lo.alpha[3] = 0
     lo.style = osc_styles.time
 
     -- center buttons
     if user_opts.track_nextprev_buttons then
-        elements["playlist_prev"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_prev")) and (osc_param.playresx >= 800 - outeroffset)
+        elements["playlist_prev"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_prev")) and (osc_param.playresx >= 500 - outeroffset)
         lo = add_layout("playlist_prev")
         lo.geometry = {x = refX - (60 + (chapter_skip_buttons and 60 or 0)) - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
     end
 
     if chapter_skip_buttons then
-        elements["chapter_prev"].visible = osc_param.playresx >= 700 - outeroffset
+        elements["chapter_prev"].visible = osc_param.playresx >= 400 - outeroffset
         lo = add_layout("chapter_prev")
         lo.geometry = {x = refX - 60 - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
     end
 
     if user_opts.jump_buttons then
-        elements["jump_backward"].visible = osc_param.playresx >= 700 - outeroffset
         lo = add_layout("jump_backward")
         lo.geometry = {x = refX - 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
     end
 
     lo = add_layout("play_pause")
-    elements["play_pause"].visible = osc_param.playresx >= 400 - outeroffset
     lo.geometry = {x = refX, y = refY - (user_opts.osc_height / 2), an = 5, w = 45, h = 28}
     lo.style = osc_styles.control_1
 
     if user_opts.jump_buttons then
-        elements["jump_forward"].visible = osc_param.playresx >= 700 - outeroffset
         lo = add_layout("jump_forward")
         lo.geometry = {x = refX + 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
     end
 
     if chapter_skip_buttons then
-        elements["chapter_next"].visible = osc_param.playresx >= 700 - outeroffset
+        elements["chapter_next"].visible = osc_param.playresx >= 400 - outeroffset
         lo = add_layout("chapter_next")
         lo.geometry = {x = refX + 60 + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
     end
 
     if user_opts.track_nextprev_buttons then
-        elements["playlist_next"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_next")) and (osc_param.playresx >= 800 - outeroffset)
+        elements["playlist_next"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_next")) and (osc_param.playresx >= 500 - outeroffset)
         lo = add_layout("playlist_next")
         lo.geometry = {x = refX + (60 + (chapter_skip_buttons and 60 or 0)) + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
         lo.style = osc_styles.control_2
@@ -2364,14 +2395,14 @@ layouts["default"] = function ()
         end
     end
 
-    right_side_button("fullscreen", 300, user_opts.fullscreen_button)
+    right_side_button("fullscreen", 550, user_opts.fullscreen_button)
     right_side_button("info", 650, user_opts.info_button)
-    right_side_button("ontop", 450, user_opts.ontop_button and not (window_controls_enabled() and user_opts.ontop_in_topbar and state.ontop))
+    right_side_button("ontop", 750, user_opts.ontop_button and not (window_controls_enabled() and user_opts.ontop_in_topbar and state.ontop))
     right_side_button("screenshot", 850, user_opts.screenshot_button)
     right_side_button("file_loop", 950, user_opts.loop_button)
     right_side_button("shuffle", 1050, user_opts.shuffle_button)
-    right_side_button("download", 1150, state.is_url and user_opts.download_button)
     right_side_button("speed", 1150, user_opts.speed_button, osc_styles.speed, 42)
+    right_side_button("download", 1150, state.is_url and user_opts.download_button)
 
     if user_opts.cache_info then
         right_side_button("cache_info", 1250, user_opts.cache_info, osc_styles.cache, user_opts.cache_info_speed and 70 or 45)

--- a/modernz.lua
+++ b/modernz.lua
@@ -2142,15 +2142,7 @@ layouts["default"] = function ()
 
     if title_and_chapter_h_with_offset == 0 then
         -- add some top padding if both title and chapter aren't displayed
-        local ch_skip = user_opts.chapter_skip_buttons and type(state.chapter_list) == "table" and next(state.chapter_list)
-        local outer = (ch_skip and 0 or 100) + (user_opts.jump_buttons and 0 or 100)
-        local timecodes_above = osc_param.playresx < (user_opts.portrait_window_trigger - outer
-            - (user_opts.playlist_button and (not user_opts.hide_empty_playlist_button or state.playlist_count > 1) and 0 or 100)
-            - (state.sub_track_count > 0 and 0 or 100)
-            - (state.audio_track_count > 0 and 0 or 100))
-        title_and_chapter_h_with_offset = timecodes_above
-            and math.max(user_opts.osc_height * 0.2, user_opts.time_codes_offset + user_opts.title_offset + user_opts.time_font_size)
-            or user_opts.osc_height * 0.2
+        title_and_chapter_h_with_offset = user_opts.osc_height * 0.2
     end
 
     local osc_geo = {
@@ -2403,7 +2395,7 @@ layouts["compact"] = function ()
 
     if title_and_chapter_h_with_offset == 0 then
         -- add some top padding if both title and chapter aren't displayed
-        title_and_chapter_h_with_offset = math.max(user_opts.osc_height * 0.2, user_opts.time_codes_offset + user_opts.title_offset + user_opts.time_font_size)
+        title_and_chapter_h_with_offset = user_opts.osc_height * 0.2
     end
 
     local osc_geo = {

--- a/modernz.lua
+++ b/modernz.lua
@@ -2221,7 +2221,7 @@ layouts["default"] = function ()
     local playlist_button = user_opts.playlist_button and (not user_opts.hide_empty_playlist_button or state.playlist_count > 1)
 
     local offset = user_opts.jump_buttons and 60 or 0
-    local outeroffset = (chapter_skip_buttons and 0 or 100) + (user_opts.jump_buttons and 0 or 100)
+    local outeroffset = (chapter_skip_buttons and 0 or 120) + (user_opts.jump_buttons and 0 or 120)
 
     local time_codes_width = get_time_codes_width()
     local chapter_title_y, title_y
@@ -2299,7 +2299,7 @@ layouts["default"] = function ()
         local vc_left = start_x - 107
         local osc_mid = refY - (user_opts.osc_height / 2)
         elements["vol_ctrl"].hover_box = vol_vis and {x1 = vc_left, y1 = osc_mid - 12, x2 = vc_left + 87, y2 = osc_mid + 12} or nil
-        start_x = vol_vis and start_x or start_x - 65
+        start_x = vol_vis and start_x or start_x - 75
     end
 
     -- time codes

--- a/modernz.lua
+++ b/modernz.lua
@@ -20,7 +20,7 @@ mp.set_property("osc", "no")
 -- do not touch, change them in modernz.conf
 local user_opts = {
     -- Language and display
-    language = "default",                  -- set language (for available options, see: https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md)
+    language = "default",                  -- set language
     layout = "default",                    -- set layout: default, compact, mini, seekbar
     icon_theme = "fluent",                 -- set icon theme. accepts "fluent" or "material"
     icon_style = "mixed",                  -- "mixed", "filled", "outline"
@@ -2528,7 +2528,7 @@ layouts["compact"] = function ()
             lo = add_layout(name)
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = w or 24, h = 24}
             lo.style = osc_styles.control_2
-            start_x = start_x + (step or 55)
+            start_x = start_x + (step or 45)
         end
     end
 
@@ -2536,7 +2536,7 @@ layouts["compact"] = function ()
     lo = add_layout("play_pause")
     lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = 24, h = 24}
     lo.style = osc_styles.control_2
-    start_x = start_x + 55
+    start_x = start_x + 45
 
     local pl_count = state.playlist_count
     local pl_pos = state.playlist_pos_1
@@ -2548,7 +2548,7 @@ layouts["compact"] = function ()
             lo = add_layout("playlist_prev")
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = 24, h = 24}
             lo.style = osc_styles.control_2
-            start_x = start_x + 55
+            start_x = start_x + 45
         end
 
         local next_vis = pl_pos < pl_count and osc_param.playresx >= 550
@@ -2557,7 +2557,7 @@ layouts["compact"] = function ()
             lo = add_layout("playlist_next")
             lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = 24, h = 24}
             lo.style = osc_styles.control_2
-            start_x = start_x + 55
+            start_x = start_x + 45
         end
     end
 
@@ -2607,7 +2607,7 @@ layouts["compact"] = function ()
             lo = add_layout(name)
             lo.geometry = {x = end_x, y = refY - (user_opts.osc_height / 2), an = 5, w = (w or 24), h = 24}
             lo.style = style or osc_styles.control_2
-            end_x = end_x - 55
+            end_x = end_x - 45
         end
     end
 

--- a/modernz.lua
+++ b/modernz.lua
@@ -21,7 +21,7 @@ mp.set_property("osc", "no")
 local user_opts = {
     -- Language and display
     language = "default",                  -- set language (for available options, see: https://github.com/Samillion/ModernZ/blob/main/docs/TRANSLATIONS.md)
-    layout = "modern",                     -- set layout: "modern" or "modern-compact"
+    layout = "default",                    -- set layout: default, compact, mini, seekbar
     icon_theme = "fluent",                 -- set icon theme. accepts "fluent" or "material"
     icon_style = "mixed",                  -- "mixed", "filled", "outline"
     font = "mpv-osd-symbols",              -- font for the OSC (default: mpv-osd-symbols or the one set in mpv.conf)
@@ -565,6 +565,7 @@ local function set_osc_styles()
         control_1 = "{\\1c&H" .. osc_color_convert(user_opts.playpause_color) .. "&\\fs" .. playpause_size .. "\\fn" .. icons.iconfont .. "}",
         control_2 = "{\\1c&H" .. osc_color_convert(user_opts.middle_buttons_color) .. "&\\fs" .. midbuttons_size .. "\\fn" .. icons.iconfont .. "}",
         control_3 = "{\\1c&H" .. osc_color_convert(user_opts.side_buttons_color) .. "&\\fs" .. sidebuttons_size .. "\\fn" .. icons.iconfont .. "}",
+        control_mini = "{\\1c&H" .. osc_color_convert(user_opts.side_buttons_color) .. "&\\fs16\\fn" .. icons.iconfont .. "}",
         element_down = "{\\1c&H" .. osc_color_convert(user_opts.held_element_color) .. "&" .. string.format("\\fscx%s\\fscy%s", user_opts.button_held_size, user_opts.button_held_size) .. "}",
         element_hover = "{" .. (hover_effects.color and "\\1c&H" .. osc_color_convert(user_opts.hover_effect_color) .. "&" or "") .. (hover_effects.size and string.format("\\fscx%s\\fscy%s", user_opts.button_hover_size, user_opts.button_hover_size) or "") .. "}",
         hover_bg = "{\\1c&H" .. osc_color_convert(user_opts.hover_effect_color) .. "&}",
@@ -2127,7 +2128,7 @@ local function setup_bg_elements(posX, posY, osc_w, osc_h, osc_alpha3, wc_alpha3
 end
 
 -- Default layout
-layouts["modern"] = function ()
+layouts["default"] = function ()
     local no_title = not user_opts.show_title
     local no_chapter = not user_opts.show_chapter_title
     local chapter_index = user_opts.show_chapter_title and (state.chapter or -1) >= 0
@@ -2233,10 +2234,8 @@ layouts["modern"] = function ()
     end
 
     -- osc title
-    local title_w = (no_chapter or not chapter_index or user_opts.chapter_above_title) and (osc_geo.w - 60 - time_codes_width) or (osc_geo.w - 50)
-    if title_w < 0 then title_w = 0 end
     elements["title"].visible = not no_title
-    geo = {x = 25, y = refY - title_y, an = 1, w = title_w, h = user_opts.title_font_size}
+    geo = {x = 25, y = refY - title_y, an = 1, w = osc_geo.w - 50, h = user_opts.title_font_size}
     lo = add_layout("title")
     lo.geometry = geo
     lo.layer = 48
@@ -2246,7 +2245,7 @@ layouts["modern"] = function ()
     -- chapter title
     if user_opts.show_chapter_title then
         elements["chapter_title"].visible = not no_chapter and chapter_index
-        geo = {x = 26, y = refY - chapter_title_y, an = 1, w = osc_geo.w - time_codes_width - 60, h = user_opts.chapter_title_font_size}
+        geo = {x = 26, y = refY - chapter_title_y, an = 1, w = osc_geo.w - 60, h = user_opts.chapter_title_font_size}
         lo = add_layout("chapter_title")
         lo.geometry = geo
         lo.layer = 48
@@ -2254,67 +2253,26 @@ layouts["modern"] = function ()
         lo.style = string.format("%s{\\clip(%f,%f,%f,%f)}", osc_styles.chapter_title, 0, 0, geo.x + geo.w, geo.y + geo.h)
     end
 
-    -- buttons
-    if user_opts.track_nextprev_buttons then
-        elements["playlist_prev"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_prev")) and (osc_param.playresx >= 500 - outeroffset)
-        lo = add_layout("playlist_prev")
-        lo.geometry = {x = refX - (60 + (chapter_skip_buttons and 60 or 0)) - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
-    if chapter_skip_buttons then
-        elements["chapter_prev"].visible = osc_param.playresx >= 400 - outeroffset
-        lo = add_layout("chapter_prev")
-        lo.geometry = {x = refX - 60 - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
-    if user_opts.jump_buttons then
-        lo = add_layout("jump_backward")
-        lo.geometry = {x = refX - 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
-    lo = add_layout("play_pause")
-    lo.geometry = {x = refX, y = refY - (user_opts.osc_height / 2), an = 5, w = 45, h = 28}
-    lo.style = osc_styles.control_1
-
-    if user_opts.jump_buttons then
-        lo = add_layout("jump_forward")
-        lo.geometry = {x = refX + 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
-    if chapter_skip_buttons then
-        elements["chapter_next"].visible = osc_param.playresx >= 400 - outeroffset
-        lo = add_layout("chapter_next")
-        lo.geometry = {x = refX + 60 + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
-    if user_opts.track_nextprev_buttons then
-        elements["playlist_next"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_next")) and (osc_param.playresx >= 500 - outeroffset)
-        lo = add_layout("playlist_next")
-        lo.geometry = {x = refX + (60 + (chapter_skip_buttons and 60 or 0)) + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
-        lo.style = osc_styles.control_2
-    end
-
+    -- left side buttons
     local start_x = 37
-    local function left_side_button(name, min_w)
-        elements[name].visible = (osc_param.playresx >= min_w - outeroffset)
-        lo = add_layout(name)
-        lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = 24, h = 24}
-        lo.style = osc_styles.control_3
-        start_x = start_x + 45
+    local function left_side_button(name, min_w, w, step)
+        local vis = osc_param.playresx >= min_w
+        elements[name].visible = vis
+        if vis then
+            lo = add_layout(name)
+            lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = w or 24, h = 24}
+            lo.style = osc_styles.control_3
+            start_x = start_x + (step or 45)
+        end
     end
 
     if playlist_button then left_side_button("playlist", 550) end
-    if audio_track and user_opts.audio_tracks_button then left_side_button("audio_track", 650) end
-    if subtitle_track and user_opts.subtitles_button then left_side_button("sub_track", 750) end
+    if audio_track and user_opts.audio_tracks_button then left_side_button("audio_track", 800) end
+    if subtitle_track and user_opts.subtitles_button then left_side_button("sub_track", 800) end
 
     if audio_track and user_opts.volume_control then
         -- volume button
-        left_side_button("vol_ctrl", 850)
+        left_side_button("vol_ctrl", 900)
         start_x = start_x - 25 -- vol_ctrl uses a narrower step (+20 not +45)
 
         -- volume bar
@@ -2341,70 +2299,97 @@ layouts["modern"] = function ()
         local vc_left = start_x - 107
         local osc_mid = refY - (user_opts.osc_height / 2)
         elements["vol_ctrl"].hover_box = vol_vis and {x1 = vc_left, y1 = osc_mid - 12, x2 = vc_left + 87, y2 = osc_mid + 12} or nil
+        start_x = vol_vis and start_x or start_x - 65
     end
 
     -- time codes
-    local auto_hide_volbar = (audio_track and user_opts.volume_control) and osc_param.playresx < (user_opts.hide_volume_bar_trigger - outeroffset)
-    local time_codes_x = start_x
-        - (auto_hide_volbar and 67 or 0) -- window width with audio track and elements
-        - (audio_track and not user_opts.volume_control and 12 or 0) -- audio track with no elements
-        - (not audio_track and 12 or 0) -- remove excess space
-    local time_codes_y = user_opts.time_codes_offset + (user_opts.osc_height / 2)
-    local narrow_win = osc_param.playresx < (
-        user_opts.portrait_window_trigger
-        - outeroffset
-        - (playlist_button and 0 or 100)
-        - (subtitle_track and 0 or 100)
-        - (audio_track and 0 or 100)
-    )
-    if narrow_win then
-        -- try to vertically align time codes to the baseline of title/chapter
-        if not user_opts.show_title and not user_opts.show_chapter_title then
-            time_codes_y = user_opts.time_codes_offset + user_opts.osc_height + user_opts.title_offset
-        elseif no_chapter or not chapter_index or user_opts.chapter_above_title then
-            time_codes_y = title_y + ((title_h - user_opts.time_font_size) * 0.25)
-        else
-            time_codes_y = chapter_title_y
-            if chapter_h ~= user_opts.time_font_size then
-                time_codes_y = time_codes_y - ((user_opts.time_font_size - chapter_h) * 0.25)
-            end
-        end
-    end
+    local time_codes_width = get_time_codes_width()
     elements["time_codes"].visible = (state.duration or 0) > 0
     lo = add_layout("time_codes")
-    lo.geometry = {x = (narrow_win and (osc_geo.w - 25) or time_codes_x), y = refY - time_codes_y, an = (narrow_win and 3 or 4), w = time_codes_width, h = user_opts.time_font_size}
+    lo.geometry = {x = start_x + 5, y = refY - (user_opts.osc_height / 2), an = 4, w = time_codes_width, h = user_opts.time_font_size}
     lo.layer = 48
     lo.alpha[3] = 0
     lo.style = osc_styles.time
 
-    -- fullscreen - info - pin - screenshot - loop - shuffle - speed - download - cache
-    local end_x = osc_geo.w - 37
-    local function right_side_button(name, min_w, style, w)
-        elements[name].visible = (osc_param.playresx >= min_w - outeroffset)
-        lo = add_layout(name)
-        lo.geometry = {x = end_x, y = refY - (user_opts.osc_height / 2), an = 5, w = (w or 24), h = 24}
-        lo.style = style or osc_styles.control_3
-        end_x = end_x - 45
+    -- center buttons
+    if user_opts.track_nextprev_buttons then
+        elements["playlist_prev"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_prev")) and (osc_param.playresx >= 800 - outeroffset)
+        lo = add_layout("playlist_prev")
+        lo.geometry = {x = refX - (60 + (chapter_skip_buttons and 60 or 0)) - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
     end
 
-    if user_opts.fullscreen_button then right_side_button("fullscreen", 550) end
-    if user_opts.info_button then right_side_button("info", 650) end
-    if ontop_button then right_side_button("ontop", 750) end
-    if user_opts.screenshot_button then right_side_button("screenshot", 850) end
-    if user_opts.loop_button then right_side_button("file_loop", 950) end
-    if user_opts.shuffle_button then right_side_button("shuffle", 1050) end
-    if user_opts.speed_button then right_side_button("speed", 1150, osc_styles.speed, 42) end
-    if user_opts.download_button and state.is_url then right_side_button("download", 1150) end
+    if chapter_skip_buttons then
+        elements["chapter_prev"].visible = osc_param.playresx >= 700 - outeroffset
+        lo = add_layout("chapter_prev")
+        lo.geometry = {x = refX - 60 - offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
+    end
+
+    if user_opts.jump_buttons then
+        elements["jump_backward"].visible = osc_param.playresx >= 700 - outeroffset
+        lo = add_layout("jump_backward")
+        lo.geometry = {x = refX - 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
+    end
+
+    lo = add_layout("play_pause")
+    elements["play_pause"].visible = osc_param.playresx >= 400 - outeroffset
+    lo.geometry = {x = refX, y = refY - (user_opts.osc_height / 2), an = 5, w = 45, h = 28}
+    lo.style = osc_styles.control_1
+
+    if user_opts.jump_buttons then
+        elements["jump_forward"].visible = osc_param.playresx >= 700 - outeroffset
+        lo = add_layout("jump_forward")
+        lo.geometry = {x = refX + 60, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
+    end
+
+    if chapter_skip_buttons then
+        elements["chapter_next"].visible = osc_param.playresx >= 700 - outeroffset
+        lo = add_layout("chapter_next")
+        lo.geometry = {x = refX + 60 + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
+    end
+
+    if user_opts.track_nextprev_buttons then
+        elements["playlist_next"].visible = (state.playlist_count > 1 or contains(user_opts.buttons_always_active, "playlist_next")) and (osc_param.playresx >= 800 - outeroffset)
+        lo = add_layout("playlist_next")
+        lo.geometry = {x = refX + (60 + (chapter_skip_buttons and 60 or 0)) + offset, y = refY - (user_opts.osc_height / 2), an = 5, w = 30, h = 24}
+        lo.style = osc_styles.control_2
+    end
+
+    -- right side buttons
+    local end_x = osc_geo.w - 37
+    local function right_side_button(name, min_w, vis_extra, style, w)
+        local vis = (osc_param.playresx >= min_w - outeroffset) and (vis_extra == nil or vis_extra)
+        elements[name].visible = vis
+        if vis then
+            lo = add_layout(name)
+            lo.geometry = {x = end_x, y = refY - (user_opts.osc_height / 2), an = 5, w = (w or 24), h = 24}
+            lo.style = style or osc_styles.control_3
+            end_x = end_x - 45
+        end
+    end
+
+    right_side_button("fullscreen", 300, user_opts.fullscreen_button)
+    right_side_button("info", 650, user_opts.info_button)
+    right_side_button("ontop", 450, user_opts.ontop_button and not (window_controls_enabled() and user_opts.ontop_in_topbar and state.ontop))
+    right_side_button("screenshot", 850, user_opts.screenshot_button)
+    right_side_button("file_loop", 950, user_opts.loop_button)
+    right_side_button("shuffle", 1050, user_opts.shuffle_button)
+    right_side_button("download", 1150, state.is_url and user_opts.download_button)
+    right_side_button("speed", 1150, user_opts.speed_button, osc_styles.speed, 42)
 
     if user_opts.cache_info then
-        right_side_button("cache_info", 1250, osc_styles.cache, user_opts.cache_info_speed and 70 or 45)
+        right_side_button("cache_info", 1250, user_opts.cache_info, osc_styles.cache, user_opts.cache_info_speed and 70 or 45)
         lo.geometry.x  = lo.geometry.x + 7
         lo.geometry.an = 6
         lo.alpha[3] = 0
     end
 end
 
-layouts["modern-compact"] = function ()
+layouts["compact"] = function ()
     local chapter_index = (state.chapter or -1) >= 0
     local no_title = not user_opts.show_title
     local no_chapter = not user_opts.show_chapter_title
@@ -2492,10 +2477,8 @@ layouts["modern-compact"] = function ()
     end
 
     -- osc title
-    local title_w = (no_chapter or not chapter_index or user_opts.chapter_above_title) and (osc_geo.w - 60 - time_codes_width) or (osc_geo.w - 50)
-    if title_w < 0 then title_w = 0 end
     elements["title"].visible = not no_title
-    geo = {x = 25, y = refY - title_y, an = 1, w = title_w, h = user_opts.title_font_size}
+    geo = {x = 25, y = refY - title_y, an = 1, w = osc_geo.w - 50, h = user_opts.title_font_size}
     lo = add_layout("title")
     lo.geometry = geo
     lo.layer = 48
@@ -2505,33 +2488,13 @@ layouts["modern-compact"] = function ()
     -- chapter title
     if user_opts.show_chapter_title then
         elements["chapter_title"].visible = not no_chapter and chapter_index
-        geo = {x = 25, y = refY - chapter_title_y, an = 1, w = osc_geo.w - time_codes_width - 60, h = user_opts.chapter_title_font_size}
+        geo = {x = 25, y = refY - chapter_title_y, an = 1, w = osc_geo.w - 60, h = user_opts.chapter_title_font_size}
         lo = add_layout("chapter_title")
         lo.geometry = geo
         lo.layer = 48
         lo.alpha[3] = 0
         lo.style = string.format("%s{\\clip(%f,%f,%f,%f)}", osc_styles.chapter_title, 0, 0, geo.x + geo.w, geo.y + geo.h)
     end
-
-    -- time codes
-    elements["time_codes"].visible = (state.duration or 0) > 0
-    local time_codes_y = user_opts.time_codes_offset
-    -- try to vertically align time codes to the baseline of title/chapter
-    if not user_opts.show_title and not user_opts.show_chapter_title then
-        time_codes_y = time_codes_y + user_opts.osc_height + user_opts.title_offset
-    elseif no_chapter or not chapter_index or user_opts.chapter_above_title then
-        time_codes_y = time_codes_y + title_y + ((title_h - user_opts.time_font_size) * 0.25)
-    else
-        time_codes_y = time_codes_y + chapter_title_y
-        if chapter_h ~= user_opts.time_font_size then
-            time_codes_y = time_codes_y - ((user_opts.time_font_size - chapter_h) * 0.25)
-        end
-    end
-    lo = add_layout("time_codes")
-    lo.geometry = {x = osc_geo.w - 25, y = refY - time_codes_y, an = 3, w = time_codes_width, h = user_opts.time_font_size}
-    lo.layer = 48
-    lo.alpha[3] = 0
-    lo.style = osc_styles.time
 
     -- left side buttons
     local start_x = 37
@@ -2546,6 +2509,7 @@ layouts["modern-compact"] = function ()
         end
     end
 
+    elements["play_pause"].visible = osc_param.playresx >= 200
     lo = add_layout("play_pause")
     lo.geometry = {x = start_x, y = refY - (user_opts.osc_height / 2), an = 5, w = 24, h = 24}
     lo.style = osc_styles.control_2
@@ -2555,7 +2519,7 @@ layouts["modern-compact"] = function ()
     local pl_pos = state.playlist_pos_1
 
     if user_opts.track_nextprev_buttons then
-        local prev_vis = pl_pos > 1 and osc_param.playresx >= 300
+        local prev_vis = pl_pos > 1 and osc_param.playresx >= 550
         elements["playlist_prev"].visible = prev_vis
         if prev_vis then
             lo = add_layout("playlist_prev")
@@ -2564,7 +2528,7 @@ layouts["modern-compact"] = function ()
             start_x = start_x + 55
         end
 
-        local next_vis = pl_pos < pl_count and osc_param.playresx >= 400
+        local next_vis = pl_pos < pl_count and osc_param.playresx >= 550
         elements["playlist_next"].visible = next_vis
         if next_vis then
             lo = add_layout("playlist_next")
@@ -2575,14 +2539,14 @@ layouts["modern-compact"] = function ()
     end
 
     if user_opts.jump_buttons then
-        left_side_button("jump_backward", 500, 30)
-        left_side_button("jump_forward", 600, 30)
+        left_side_button("jump_backward", 700, 30)
+        left_side_button("jump_forward", 700, 30)
     end
 
     if state.audio_track_count > 0 and user_opts.volume_control then
-        left_side_button("vol_ctrl", 700, nil, 20)
+        left_side_button("vol_ctrl", 800, nil, 20)
 
-        local vol_vis = osc_param.playresx >= 850
+        local vol_vis = osc_param.playresx >= 900
         ne = new_element("volumebarbg", "box")
         ne.visible = vol_vis
         elements["volumebar"].visible = vol_vis
@@ -2624,6 +2588,181 @@ layouts["modern-compact"] = function ()
         end
     end
 
+    right_side_button("fullscreen", 300, user_opts.fullscreen_button)
+    right_side_button("ontop", 400, user_opts.ontop_button and not (window_controls_enabled() and user_opts.ontop_in_topbar and state.ontop))
+    right_side_button("sub_track", 500, user_opts.subtitles_button and state.sub_track_count > 0)
+    right_side_button("audio_track", 600, user_opts.audio_tracks_button and state.audio_track_count > 0)
+    right_side_button("playlist", 300, user_opts.playlist_button)
+    right_side_button("download", 800, state.is_url and user_opts.download_button)
+    right_side_button("speed", 800, user_opts.speed_button, osc_styles.speed, 42)
+
+    -- time codes
+    local time_codes_width = get_time_codes_width()
+    elements["time_codes"].visible = (state.duration or 0) > 0
+    lo = add_layout("time_codes")
+    lo.geometry = {x = end_x + 20, y = refY - (user_opts.osc_height / 2), an = 6, w = time_codes_width, h = 20}
+    lo.layer = 48
+    lo.alpha[3] = 0
+    lo.style = osc_styles.time
+end
+
+layouts["mini"] = function ()
+    local osc_height = 30
+    local first_row_y = 25
+    local second_row_y = 25
+    local osc_offset = first_row_y + second_row_y
+
+    local osc_geo = {
+        w = osc_param.playresx,
+        h = osc_height + osc_offset
+    }
+
+    -- update bottom margin
+    osc_param.video_margins.b = osc_geo.h / osc_param.playresy
+
+    -- origin of the controllers, left/bottom corner
+    local posX = 0
+    local posY = osc_param.playresy
+
+    osc_param.areas = {} -- delete areas
+
+    -- area for active mouse input
+    add_area("input", get_hitbox_coords(posX, posY, 1, osc_geo.w, osc_geo.h))
+
+    -- area for show/hide
+    local osc_top = posY - osc_geo.h
+    add_area("showhide", 0, get_align(-1 + (2 * user_opts.deadzonesize), osc_top, 0, 0), osc_param.playresx, osc_param.playresy)
+
+    local lo, ne
+
+    -- osc background
+    setup_bg_elements(posX, posY, osc_geo.w, osc_geo.h, user_opts.fade_transparency_strength, user_opts.window_fade_transparency_strength)
+
+    local refX = osc_geo.w / 2
+    local refY = posY
+
+    -- seekbar
+    ne = new_element("seekbarbg", "box")
+    ne.visible = user_opts.nibbles_style ~= "gap"
+    lo = add_layout("seekbarbg")
+    local seekbar_bg_h = seekbar_height_style.height
+    lo.geometry = {x = refX, y = refY - first_row_y - second_row_y, an = 5, w = osc_geo.w - 30, h = seekbar_bg_h}
+    lo.layer = 15
+    lo.style = osc_styles.seekbar_bg
+    lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
+    lo.alpha[1] = 128
+
+    lo = add_layout("seekbar")
+    local seekbar_h = 18
+    lo.geometry = {x = refX, y = refY - first_row_y - second_row_y, an = 5, w = osc_geo.w - 30, h = seekbar_h}
+    lo.layer = 49
+    lo.style = osc_styles.seekbar_fg
+    lo.slider.handle_color = user_opts.seek_handle_color
+    lo.slider.handle_border = user_opts.seek_handle_border_color
+    lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
+    lo.slider.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
+    lo.slider.tooltip_an = 2
+
+    if user_opts.persistent_progress or state.persistent_progress_toggle then
+        lo = add_layout("persistent_seekbar")
+        lo.geometry = {x = refX, y = refY, an = 5, w = osc_geo.w, h = user_opts.persistent_progress_height}
+        lo.style = osc_styles.seekbar_fg
+        lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
+        lo.slider.tooltip_an = 0
+    end
+
+    -- left side buttons
+    local start_x = 37
+    local function left_side_button(name, min_w, w, step)
+        local vis = osc_param.playresx >= min_w
+        elements[name].visible = vis
+        if vis then
+            lo = add_layout(name)
+            lo.geometry = {x = start_x, y = refY - first_row_y, an = 5, w = w or 24, h = 20}
+            lo.style = osc_styles.control_mini
+            start_x = start_x + (step or 35)
+        end
+    end
+
+    elements["play_pause"].visible = osc_param.playresx >= 200
+    lo = add_layout("play_pause")
+    lo.geometry = {x = start_x, y = refY - first_row_y, an = 5, w = 24, h = 20}
+    lo.style = osc_styles.control_mini
+    start_x = start_x + 35
+
+    local pl_count = state.playlist_count
+    local pl_pos = state.playlist_pos_1
+
+    if user_opts.track_nextprev_buttons then
+        local prev_vis = pl_pos > 1 and osc_param.playresx >= 350
+        elements["playlist_prev"].visible = prev_vis
+        if prev_vis then
+            lo = add_layout("playlist_prev")
+            lo.geometry = {x = start_x, y = refY - first_row_y, an = 5, w = 24, h = 20}
+            lo.style = osc_styles.control_mini
+            start_x = start_x + 35
+        end
+
+        local next_vis = pl_pos < pl_count and osc_param.playresx >= 350
+        elements["playlist_next"].visible = next_vis
+        if next_vis then
+            lo = add_layout("playlist_next")
+            lo.geometry = {x = start_x, y = refY - first_row_y, an = 5, w = 24, h = 20}
+            lo.style = osc_styles.control_mini
+            start_x = start_x + 35
+        end
+    end
+
+    if user_opts.jump_buttons then
+        left_side_button("jump_backward", 450, 30)
+        left_side_button("jump_forward", 450, 30)
+    end
+
+    if state.audio_track_count > 0 and user_opts.volume_control then
+        left_side_button("vol_ctrl", 500, nil, 20)
+
+        local vol_vis = osc_param.playresx >= 650
+        ne = new_element("volumebarbg", "box")
+        ne.visible = vol_vis
+        elements["volumebar"].visible = vol_vis
+        if vol_vis then
+            lo = add_layout("volumebarbg")
+            lo.geometry = {x = start_x, y = refY - first_row_y, an = 4, w = 55, h = 4}
+            lo.layer = 15
+            lo.alpha[1] = 128
+            lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_bg or osc_styles.volumebar_bg
+            lo.box.radius = user_opts.slider_rounded_corners and 2 or 0
+
+            lo = add_layout("volumebar")
+            lo.geometry = {x = start_x, y = refY - first_row_y, an = 4, w = 55, h = 10}
+            lo.style = user_opts.volumebar_match_seek_color and osc_styles.seekbar_fg or osc_styles.volumebar_fg
+            lo.slider.handle_color = user_opts.volumebar_match_seek_color and user_opts.seekbarfg_color or user_opts.side_buttons_color
+            lo.slider.gap = 3
+            lo.slider.radius = user_opts.slider_rounded_corners and 2 or 0
+            lo.slider.tooltip_an = 2
+            start_x = start_x + 75
+            -- vol_ctrl center = bar_start - 20; bar_start = start_x - 75; left edge = center - 10
+            local vc_left = start_x - 107
+            local osc_mid = refY - first_row_y
+            elements["vol_ctrl"].hover_box = {x1 = vc_left, y1 = osc_mid - 10, x2 = vc_left + 87, y2 = osc_mid + 10}
+        else
+            elements["vol_ctrl"].hover_box = nil
+        end
+    end
+
+    -- right side buttons
+    local end_x = osc_geo.w - 37
+    local function right_side_button(name, min_w, vis_extra, style, w)
+        local vis = (osc_param.playresx >= min_w) and (vis_extra == nil or vis_extra)
+        elements[name].visible = vis
+        if vis then
+            lo = add_layout(name)
+            lo.geometry = {x = end_x, y = refY - first_row_y, an = 5, w = (w or 24), h = 20}
+            lo.style = style or osc_styles.control_mini
+            end_x = end_x - 35
+        end
+    end
+
     right_side_button("fullscreen", 250, user_opts.fullscreen_button)
     right_side_button("ontop", 300, user_opts.ontop_button and not (window_controls_enabled() and user_opts.ontop_in_topbar and state.ontop))
     right_side_button("sub_track", 400, user_opts.subtitles_button and state.sub_track_count > 0)
@@ -2632,13 +2771,89 @@ layouts["modern-compact"] = function ()
     right_side_button("download", 700, state.is_url and user_opts.download_button)
     right_side_button("speed", 700, user_opts.speed_button, osc_styles.speed, 42)
 
-    elements["cache_info"].visible = user_opts.cache_info and osc_geo.w >= 850
-    if elements["cache_info"].visible then
-        lo = add_layout("cache_info")
-        lo.geometry = {x = end_x + 7, y = refY - (user_opts.osc_height / 2), an = 6, w = (user_opts.cache_info_speed and 70 or 45), h = 24}
-        lo.alpha[3] = 0
-        lo.style = osc_styles.cache
+    -- time codes
+    local time_codes_width = get_time_codes_width()
+    elements["time_codes"].visible = (state.duration or 0) > 0
+    lo = add_layout("time_codes")
+    lo.geometry = {x = end_x, y = refY - first_row_y, an = 6, w = time_codes_width, h = 20}
+    lo.layer = 48
+    lo.alpha[3] = 0
+    lo.style = osc_styles.time
+end
+
+layouts["seekbar"] = function ()
+    local osc_height = 30
+    local first_row_y = 25
+    local second_row_y = 15
+    local osc_offset = first_row_y + second_row_y
+
+    local osc_geo = {
+        w = osc_param.playresx,
+        h = osc_height + osc_offset
+    }
+
+    -- update bottom margin
+    osc_param.video_margins.b = osc_geo.h / osc_param.playresy
+
+    -- origin of the controllers, left/bottom corner
+    local posX = 0
+    local posY = osc_param.playresy
+
+    osc_param.areas = {} -- delete areas
+
+    -- area for active mouse input
+    add_area("input", get_hitbox_coords(posX, posY, 1, osc_geo.w, osc_geo.h))
+
+    -- area for show/hide
+    local osc_top = posY - osc_geo.h
+    add_area("showhide", 0, get_align(-1 + (2 * user_opts.deadzonesize), osc_top, 0, 0), osc_param.playresx, osc_param.playresy)
+
+    local lo, ne
+
+    -- osc background
+    setup_bg_elements(posX, posY, osc_geo.w, osc_geo.h, user_opts.fade_transparency_strength, user_opts.window_fade_transparency_strength)
+
+    local refX = osc_geo.w / 2
+    local refY = posY
+
+    -- seekbar
+    ne = new_element("seekbarbg", "box")
+    ne.visible = user_opts.nibbles_style ~= "gap"
+    lo = add_layout("seekbarbg")
+    local seekbar_bg_h = seekbar_height_style.height
+    lo.geometry = {x = refX, y = refY - first_row_y, an = 5, w = osc_geo.w - 30, h = seekbar_bg_h}
+    lo.layer = 15
+    lo.style = osc_styles.seekbar_bg
+    lo.box.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
+    lo.alpha[1] = 128
+
+    lo = add_layout("seekbar")
+    local seekbar_h = 18
+    lo.geometry = {x = refX, y = refY - first_row_y, an = 5, w = osc_geo.w - 30, h = seekbar_h}
+    lo.layer = 49
+    lo.style = osc_styles.seekbar_fg
+    lo.slider.handle_color = user_opts.seek_handle_color
+    lo.slider.handle_border = user_opts.seek_handle_border_color
+    lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
+    lo.slider.radius = user_opts.slider_rounded_corners and seekbar_height_style.radius or 0
+    lo.slider.tooltip_an = 2
+
+    if user_opts.persistent_progress or state.persistent_progress_toggle then
+        lo = add_layout("persistent_seekbar")
+        lo.geometry = {x = refX, y = refY, an = 5, w = osc_geo.w, h = user_opts.persistent_progress_height}
+        lo.style = osc_styles.seekbar_fg
+        lo.slider.gap = (seekbar_h - seekbar_bg_h) / 2.0
+        lo.slider.tooltip_an = 0
     end
+
+    -- time codes
+    local time_codes_width = get_time_codes_width()
+    elements["time_codes"].visible = (state.duration or 0) > 0
+    lo = add_layout("time_codes")
+    lo.geometry = {x = osc_geo.w - 25, y = refY - first_row_y - second_row_y, an = 3, w = time_codes_width, h = user_opts.time_font_size}
+    lo.layer = 48
+    lo.alpha[3] = 0
+    lo.style = osc_styles.time
 end
 
 layouts["modern-image"] = function ()
@@ -3353,7 +3568,7 @@ local function osc_init()
     elseif layouts[user_opts.layout] then
         layouts[user_opts.layout]()
     else
-        layouts["modern"]()
+        layouts["default"]()
     end
 
     -- load window controls


### PR DESCRIPTION
Fixes: https://github.com/Samillion/ModernZ/issues/737

**Changes**:
- Add `mini` and `seekbar` layouts
- Change existing layout names to `default` and `compact`
- `compact`: move time codes to same row as buttons
- `default`: Move code blocks to be structurally sound, in order of buttons: left, center, right
- Adjust logic in right and left side buttons helpers for all layouts (now they're matching in behavior)
- General improvements to default and compact layouts element visibility based on window width
- Remove unused code from default and compact layouts

<table>
    <thead>
        <tr>
            <th><code>mini</code></th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><img width="1961" height="125" alt="layout_mini" src="https://github.com/user-attachments/assets/a4f5d467-0286-4280-b284-9aaec8e6e42f" /></td>
        </tr>
    </tbody>
</table>
<table>
    <thead>
        <tr>
            <th><code>seekbar</code></th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td><img width="1961" height="124" alt="layout_seekbar" src="https://github.com/user-attachments/assets/4479b9d3-cdfb-4ebb-ac85-8d4c8ba101e1" /></td>
        </tr>
    </tbody>
</table>