### PR TITLE
refactor: remove unused maxchars dead code

### DIFF
--- a/modernz.lua
+++ b/modernz.lua
@@ -1771,19 +1771,6 @@ local function render_elements(master_ass, osc_vis, wc_vis)
                 buttontext = element.content -- text objects
             end
 
-            local maxchars = element.layout.button.maxchars
-            if maxchars ~= nil and #buttontext > maxchars then
-                local max_ratio = 1.25  -- up to 25% more chars while shrinking
-                local limit = math.max(0, math.floor(maxchars * max_ratio) - 3)
-                if #buttontext > limit then
-                    while (#buttontext > limit) do
-                        buttontext = buttontext:gsub(".[\128-\191]*$", "")
-                    end
-                    buttontext = buttontext .. "..."
-                end
-                buttontext = string.format("{\\fscx%f}", (maxchars/#buttontext)*100) .. buttontext
-            end
-
             -- add hover effects
             local button_lo = element.layout.button
             local is_clickable = element.eventresponder and (element.eventresponder["mbtn_left_down"] ~= nil or element.eventresponder["mbtn_left_up"] ~= nil)
@@ -1998,7 +1985,6 @@ local function add_layout(name)
 
         if elements[name].type == "button" then
             elements[name].layout.button = {
-                maxchars = nil,
                 hoverstyle = osc_styles.element_hover,
             }
         elseif elements[name].type == "slider" then


### PR DESCRIPTION
**Changes**:
- Remove unused `maxchars` dead code
  - All this time `maxchars` was set to `nil`, so the condition is never true and never runs
  - ModernZ relies on clipping the title(s) based on window width, not maximum characters count
  - This works in `osc.lua` with fixed width layouts, ours is more dynamic and adjusts based on window size

**Note**:
While we can simply assign an arbitrary value to `maxchars` (e.g. `150` characters), the change it applies looks unpleasant. It's not just a simple adding of three dots at the end. It uses `\\fscx` to shrink it, which makes the title look compressed and weird.

However, I'm open to suggestions, this doesn't have to be removed if it can be used properly.