### PR TITLE
fix: add a proper method to disable seek_handle_border_color

### DIFF
--- a/docs/USER_OPTS.md
+++ b/docs/USER_OPTS.md
@@ -146,7 +146,7 @@ watch-later-options-remove=osd-margin-y
 | seekbarfg_color                   | `#FF8232` | color of the seekbar progress                                                                     |
 | seekbarbg_color                   | `#999999` | color of the remaining seekbar                                                                    |
 | seek_handle_color                 | `#C96508` | color of the seekbar handle                                                                       |
-| seek_handle_border_color          | `#FF8232` | inner border color drawn inside the seekbar handle                                                |
+| seek_handle_border_color          | `#FF8232` | inner border color drawn inside the seekbar handle (set to `disable` to disable)                  |
 | volumebar_match_seek_color        | no        | match volume bar color with seekbar color (ignores `side_buttons_color`)                          |
 | time_color                        | `#FFFFFF` | color of the timestamps                                                                           |
 | chapter_title_color               | `#FFFFFF` | color of the chapter title                                                                        |

--- a/modernz.conf
+++ b/modernz.conf
@@ -221,7 +221,7 @@ seekbarfg_color=#FF8232
 seekbarbg_color=#999999
 # color of the seekbar handle
 seek_handle_color=#C96508
-# inner border color drawn inside the seekbar handle
+# inner border color drawn inside the seekbar handle (set to disable to disable)
 seek_handle_border_color=#FF8232
 # match volume bar color with seekbar color (ignores side_buttons_color)
 volumebar_match_seek_color=no

--- a/modernz.lua
+++ b/modernz.lua
@@ -141,7 +141,7 @@ local user_opts = {
     seekbarfg_color = "#FF8232",           -- color of the seekbar progress
     seekbarbg_color = "#999999",           -- color of the remaining seekbar
     seek_handle_color = "#C96508",         -- color of the seekbar handle
-    seek_handle_border_color = "#FF8232",  -- inner border color drawn inside the seekbar handle (set to "" to disable)
+    seek_handle_border_color = "#FF8232",  -- inner border color drawn inside the seekbar handle (set to "disable" to disable)
     volumebar_match_seek_color = false,    -- match volume bar color with seekbar color (ignores side_buttons_color)
     time_color = "#FFFFFF",                -- color of the timestamps (below seekbar)
     chapter_title_color = "#FFFFFF",       -- color of the chapter title
@@ -4379,6 +4379,15 @@ local function validate_user_opts()
     validate_string_opt("keeponpause",  {"no", "bottombar", "both"}, "no")
     validate_string_opt("deadzone_hide", {"instant", "timeout"}, "instant")
 
+    local hbc = user_opts.seek_handle_border_color
+    if hbc == "disable" then
+        hbc = ""
+    elseif hbc ~= "" and hbc:find("^#%x%x%x%x%x%x$") == nil then
+        msg.warn("'" .. hbc .. "' is not a valid color for seek_handle_border_color, border disabled")
+        hbc = ""
+    end
+    user_opts.seek_handle_border_color = hbc
+
     local colors = {
         user_opts.osc_color, user_opts.seekbarfg_color, user_opts.seekbarbg_color, user_opts.title_color, user_opts.time_color,
         user_opts.side_buttons_color, user_opts.middle_buttons_color, user_opts.playpause_color, user_opts.window_title_color,
@@ -4387,10 +4396,6 @@ local function validate_user_opts()
         user_opts.windowcontrols_min_hover, user_opts.cache_info_color, user_opts.thumbnail_box_outline, user_opts.nibble_color,
         user_opts.nibble_current_color, user_opts.seek_handle_color, user_opts.ab_loop_color,
     }
-
-    if user_opts.seek_handle_border_color ~= "" then
-        colors[#colors + 1] = user_opts.seek_handle_border_color
-    end
 
     for _, color in pairs(colors) do
         if color:find("^#%x%x%x%x%x%x$") == nil then


### PR DESCRIPTION
## Changes
- Add a proper method to disable `seek_handle_border_color` in `modernz.conf`
  - `seek_handle_border_color=disable` to disable it


## Explanation
The description to disable it was:
```
inner border color drawn inside the seekbar handle (set to "" to disable)
```

This does not work for `modernz.conf`, because setting it to the following:

```EditorConfig
# nothing after =
seek_handle_border_color=

# a single space after =
seek_handle_border_color= 
```

| Result: (black color border) |
| ----------------------------- |
| ![before_fix](https://github.com/user-attachments/assets/2384d041-f1d7-42c4-aa00-5077348e08e8) |

## Fix

The option can now be disabled properly with `seek_handle_border_color=disable`.

| Result: |
| ----------------------------- |
| ![after_fix](https://github.com/user-attachments/assets/ac376e36-5ec9-456e-adbb-290df8dc12e0) |
